### PR TITLE
[poc] compute: nested rendering contexts

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -44,100 +44,184 @@ use crate::typedefs::{
     RowSpine,
 };
 
-/// Dataflow-local collections and arrangements.
+/// The context within which rendering occurs.
 ///
-/// A context means to wrap available data assets and present them in an easy-to-use manner.
-/// These assets include dataflow-local collections and arrangements, as well as imported
-/// arrangements from outside the dataflow.
-///
-/// Context has two timestamp types, one from `S::Timestamp` and one from `T`, where the
-/// former must refine the latter. The former is the timestamp used by the scope in question,
-/// and the latter is the timestamp of imported traces. The two may be different in the case
-/// of regions or iteration.
-pub struct Context<S: Scope, T = mz_repr::Timestamp>
-where
-    T: Timestamp + Lattice + Columnation,
-    S::Timestamp: Lattice + Refines<T> + Columnation,
-{
-    /// The scope within which all managed collections exist.
+/// Rendering functions usually receive a `Context` object as their first argument that determines
+/// the scope within which collections are to be rendered and stores global information about the
+/// dataflow.
+pub(super) trait Context: Sized {
+    type Timestamp: RenderTimestamp;
+    type Scope: Scope<Timestamp = Self::Timestamp>;
+
+    /// Returns a reference to the scope within which collections are to be rendered.
+    fn scope(&self) -> &Self::Scope;
+
+    /// Returns a mutable reference to the scope within which collections are to be rendered.
+    fn scope_mut(&mut self) -> &mut Self::Scope;
+
+    /// Returns static context information about the dataflow.
+    fn static_(&self) -> &StaticContext;
+
+    /// Returns token that operators can probe to know whether the dataflow is shutting down.
+    fn shutdown_token(&self) -> &ShutdownToken;
+
+    /// Sets the shutdown token.
+    fn set_shutdown_token(&mut self, token: ShutdownToken);
+
+    /// Inserts a collection bundle by an identifier.
     ///
-    /// It is an error to add any collections not contained in this scope.
-    pub(crate) scope: S,
-    /// The debug name of the dataflow associated with this context.
-    pub debug_name: String,
-    /// The Timely ID of the dataflow associated with this context.
-    pub dataflow_id: usize,
-    /// Frontier before which updates should not be emitted.
+    /// This is expected to be used to install external collections (sources, indexes, other
+    /// views), as well as for `Let` bindings of local collections.
+    fn insert_id(
+        &mut self,
+        id: Id,
+        collection: CollectionBundle<Self::Scope>,
+    ) -> Option<CollectionBundle<Self::Scope>>;
+
+    /// Removes a collection bundle by an identifier.
+    ///
+    /// The primary use of this method is uninstalling `Let` bindings.
+    fn remove_id(&mut self, id: Id) -> Option<CollectionBundle<Self::Scope>>;
+
+    /// Melds a collection bundle to whatever exists.
+    fn update_id(&mut self, id: Id, collection: CollectionBundle<Self::Scope>);
+
+    /// Melds a collection bundle to whatever exists.
+    fn lookup_id(&self, id: Id) -> Option<CollectionBundle<Self::Scope>>;
+
+    /// Returns the debug name of the dataflow associated with this context.
+    fn debug_name(&self) -> &str {
+        &self.static_().debug_name
+    }
+
+    /// Returns the Timely ID of the dataflow associated with this context.
+    fn dataflow_id(&self) -> usize {
+        self.static_().dataflow_id
+    }
+
+    /// Returns the frontier before which updates should not be emitted.
     ///
     /// We *must* apply it to sinks, to ensure correct outputs.
     /// We *should* apply it to sources and imported traces, because it improves performance.
-    pub as_of_frontier: Antichain<T>,
-    /// Frontier after which updates should not be emitted.
+    fn as_of(&self) -> &Antichain<mz_repr::Timestamp> {
+        &self.static_().as_of
+    }
+
+    /// Returns the frontier after which updates should not be emitted.
+    ///
     /// Used to limit the amount of work done when appropriate.
-    pub until: Antichain<T>,
-    /// Bindings of identifiers to collections.
-    pub bindings: BTreeMap<Id, CollectionBundle<S, T>>,
-    /// A token that operators can probe to know whether the dataflow is shutting down.
-    pub(super) shutdown_token: ShutdownToken,
-    /// Specification for rendering linear joins.
-    pub(super) linear_join_spec: LinearJoinSpec,
-    pub(super) enable_specialized_arrangements: bool,
+    fn until(&self) -> &Antichain<mz_repr::Timestamp> {
+        &self.static_().until
+    }
+
+    /// Returns the specification for rendering linear joins.
+    fn linear_join_spec(&self) -> LinearJoinSpec {
+        self.static_().linear_join_spec
+    }
+
+    /// Returns whether arrangement specialization is enabled.
+    fn enable_specialized_arrangements(&self) -> bool {
+        self.static_().enable_specialized_arrangements
+    }
+
+    /// Returns a shutdown-aware error logger to be used by rendered operators.
+    fn error_logger(&self) -> ErrorLogger {
+        ErrorLogger::new(self.shutdown_token().clone(), self.debug_name().into())
+    }
 }
 
-impl<S: Scope> Context<S>
-where
-    S::Timestamp: Lattice + Refines<mz_repr::Timestamp> + Columnation,
-{
-    /// Creates a new empty Context.
-    pub fn for_dataflow_in<Plan>(
-        dataflow: &DataflowDescription<Plan, CollectionMetadata>,
-        scope: S,
-    ) -> Self {
-        use mz_ore::collections::CollectionExt as IteratorExt;
-        let dataflow_id = scope.addr().into_first();
-        let as_of_frontier = dataflow
-            .as_of
-            .clone()
-            .unwrap_or_else(|| Antichain::from_elem(Timestamp::minimum()));
+/// Static context information about a dataflow.
+pub(super) struct StaticContext {
+    debug_name: String,
+    dataflow_id: usize,
+    as_of: Antichain<mz_repr::Timestamp>,
+    until: Antichain<mz_repr::Timestamp>,
+    linear_join_spec: LinearJoinSpec,
+    enable_specialized_arrangements: bool,
+}
 
+/// The root context within which a dataflow is rendered.
+pub(super) struct RootContext<S>
+where
+    S: Scope,
+    S::Timestamp: RenderTimestamp,
+{
+    scope: S,
+    bindings: BTreeMap<Id, CollectionBundle<S>>,
+    static_: StaticContext,
+    shutdown_token: ShutdownToken,
+}
+
+impl<S> RootContext<S>
+where
+    S: Scope,
+    S::Timestamp: RenderTimestamp,
+{
+    /// Creates a new `RootContext` for the given dataflow.
+    pub fn new<P>(
+        dataflow: &DataflowDescription<P, CollectionMetadata>,
+        scope: S,
+        linear_join_spec: LinearJoinSpec,
+        enable_specialized_arrangements: bool,
+    ) -> Self {
+        let static_ = StaticContext {
+            debug_name: dataflow.debug_name.clone(),
+            dataflow_id: scope.addr()[0],
+            as_of: dataflow.as_of.clone().expect("missing as_of"),
+            until: dataflow.until.clone(),
+            linear_join_spec,
+            enable_specialized_arrangements,
+        };
         Self {
             scope,
-            debug_name: dataflow.debug_name.clone(),
-            dataflow_id,
-            as_of_frontier,
-            until: dataflow.until.clone(),
-            bindings: BTreeMap::new(),
+            bindings: Default::default(),
+            static_,
             shutdown_token: Default::default(),
-            linear_join_spec: Default::default(),
-            enable_specialized_arrangements: Default::default(),
         }
     }
 }
 
-impl<S: Scope, T> Context<S, T>
+impl<S> Context for RootContext<S>
 where
-    T: Timestamp + Lattice + Columnation,
-    S::Timestamp: Lattice + Refines<T> + Columnation,
+    S: Scope,
+    S::Timestamp: RenderTimestamp,
 {
-    /// Insert a collection bundle by an identifier.
-    ///
-    /// This is expected to be used to install external collections (sources, indexes, other views),
-    /// as well as for `Let` bindings of local collections.
-    pub fn insert_id(
+    type Timestamp = S::Timestamp;
+    type Scope = S;
+
+    fn scope(&self) -> &Self::Scope {
+        &self.scope
+    }
+
+    fn scope_mut(&mut self) -> &mut Self::Scope {
+        &mut self.scope
+    }
+
+    fn static_(&self) -> &StaticContext {
+        &self.static_
+    }
+
+    fn shutdown_token(&self) -> &ShutdownToken {
+        &self.shutdown_token
+    }
+
+    fn set_shutdown_token(&mut self, token: ShutdownToken) {
+        self.shutdown_token = token;
+    }
+
+    fn insert_id(
         &mut self,
         id: Id,
-        collection: CollectionBundle<S, T>,
-    ) -> Option<CollectionBundle<S, T>> {
+        collection: CollectionBundle<Self::Scope>,
+    ) -> Option<CollectionBundle<Self::Scope>> {
         self.bindings.insert(id, collection)
     }
-    /// Remove a collection bundle by an identifier.
-    ///
-    /// The primary use of this method is uninstalling `Let` bindings.
-    pub fn remove_id(&mut self, id: Id) -> Option<CollectionBundle<S, T>> {
+
+    fn remove_id(&mut self, id: Id) -> Option<CollectionBundle<Self::Scope>> {
         self.bindings.remove(&id)
     }
-    /// Melds a collection bundle to whatever exists.
-    pub fn update_id(&mut self, id: Id, collection: CollectionBundle<S, T>) {
+
+    fn update_id(&mut self, id: Id, collection: CollectionBundle<Self::Scope>) {
         if !self.bindings.contains_key(&id) {
             self.bindings.insert(id, collection);
         } else {
@@ -153,13 +237,9 @@ where
             }
         }
     }
-    /// Look up a collection bundle by an identifier.
-    pub fn lookup_id(&self, id: Id) -> Option<CollectionBundle<S, T>> {
-        self.bindings.get(&id).cloned()
-    }
 
-    pub(super) fn error_logger(&self) -> ErrorLogger {
-        ErrorLogger::new(self.shutdown_token.clone(), self.debug_name.clone())
+    fn lookup_id(&self, id: Id) -> Option<CollectionBundle<Self::Scope>> {
+        self.bindings.get(&id).cloned()
     }
 }
 

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -19,90 +19,90 @@ where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
 {
-    /// Renders `relation_expr` followed by `map_filter_project` if provided.
-    pub fn render_flat_map(
-        &mut self,
-        input: CollectionBundle<G>,
-        func: TableFunc,
-        exprs: Vec<MirScalarExpr>,
-        mfp: MapFilterProject,
-        input_key: Option<Vec<MirScalarExpr>>,
-    ) -> CollectionBundle<G> {
-        let until = self.until.clone();
-        let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
-        let (ok_collection, err_collection) = input.as_specific_collection(input_key.as_deref());
-        let (oks, errs) = ok_collection.inner.flat_map_fallible("FlatMapStage", {
-            let mut datums = DatumVec::new();
-            move |(input_row, mut time, diff)| {
-                let temp_storage = RowArena::new();
-                // Unpack datums and capture its length (to rewind MFP eval).
-                let mut datums_local = datums.borrow_with(&input_row);
-                let datums_len = datums_local.len();
-                let exprs = exprs
-                    .iter()
-                    .map(|e| e.eval(&datums_local, &temp_storage))
-                    .collect::<Result<Vec<_>, _>>();
-                let exprs = match exprs {
-                    Ok(exprs) => exprs,
-                    Err(e) => return vec![(Err((e.into(), time, diff)))],
-                };
-                let output_rows = match func.eval(&exprs, &temp_storage) {
-                    Ok(exprs) => exprs,
-                    Err(e) => return vec![(Err((e.into(), time, diff)))],
-                };
+/// Renders `relation_expr` followed by `map_filter_project` if provided.
+pub fn render_flat_map(
+    &mut self,
+    input: CollectionBundle<G>,
+    func: TableFunc,
+    exprs: Vec<MirScalarExpr>,
+    mfp: MapFilterProject,
+    input_key: Option<Vec<MirScalarExpr>>,
+) -> CollectionBundle<G> {
+    let until = self.until.clone();
+    let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
+    let (ok_collection, err_collection) = input.as_specific_collection(input_key.as_deref());
+    let (oks, errs) = ok_collection.inner.flat_map_fallible("FlatMapStage", {
+        let mut datums = DatumVec::new();
+        move |(input_row, mut time, diff)| {
+            let temp_storage = RowArena::new();
+            // Unpack datums and capture its length (to rewind MFP eval).
+            let mut datums_local = datums.borrow_with(&input_row);
+            let datums_len = datums_local.len();
+            let exprs = exprs
+                .iter()
+                .map(|e| e.eval(&datums_local, &temp_storage))
+                .collect::<Result<Vec<_>, _>>();
+            let exprs = match exprs {
+                Ok(exprs) => exprs,
+                Err(e) => return vec![(Err((e.into(), time, diff)))],
+            };
+            let output_rows = match func.eval(&exprs, &temp_storage) {
+                Ok(exprs) => exprs,
+                Err(e) => return vec![(Err((e.into(), time, diff)))],
+            };
 
-                use crate::render::RenderTimestamp;
-                let event_time = time.event_time().clone();
+            use crate::render::RenderTimestamp;
+            let event_time = time.event_time().clone();
 
-                // Declare borrows outside the closure so that appropriately lifetimed
-                // borrows are moved in and used by `mfp.evaluate`.
-                let until = &until;
-                let temp_storage = &temp_storage;
-                let mfp_plan = &mfp_plan;
-                let output_rows_vec: Vec<_> = output_rows.collect();
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
-                let row_builder = &mut row_builder;
-                output_rows_vec
-                    .iter()
-                    .flat_map(move |(output_row, r)| {
-                        // Remove any additional columns added in prior evaluation.
-                        datums_local.truncate(datums_len);
-                        // Extend datums with additional columns, replace some with dummy values.
-                        datums_local.extend(output_row.iter());
-                        mfp_plan
-                            .evaluate(
-                                &mut datums_local,
-                                temp_storage,
-                                event_time,
-                                diff * *r,
-                                |time| !until.less_equal(time),
-                                row_builder,
-                            )
-                            .collect::<Vec<_>>()
-                    })
-                    .map(|x| match x {
-                        Ok((row, event_time, diff)) => {
-                            // Copy the whole time, and re-populate event time.
-                            let mut time = time.clone();
-                            *time.event_time() = event_time;
-                            Ok((row, time, diff))
-                        }
-                        Err((e, event_time, diff)) => {
-                            // Copy the whole time, and re-populate event time.
-                            let mut time = time.clone();
-                            *time.event_time() = event_time;
-                            Err((e, time, diff))
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            }
-        });
+            // Declare borrows outside the closure so that appropriately lifetimed
+            // borrows are moved in and used by `mfp.evaluate`.
+            let until = &until;
+            let temp_storage = &temp_storage;
+            let mfp_plan = &mfp_plan;
+            let output_rows_vec: Vec<_> = output_rows.collect();
+            let binding = SharedRow::get();
+            let mut row_builder = binding.borrow_mut();
+            let row_builder = &mut row_builder;
+            output_rows_vec
+                .iter()
+                .flat_map(move |(output_row, r)| {
+                    // Remove any additional columns added in prior evaluation.
+                    datums_local.truncate(datums_len);
+                    // Extend datums with additional columns, replace some with dummy values.
+                    datums_local.extend(output_row.iter());
+                    mfp_plan
+                        .evaluate(
+                            &mut datums_local,
+                            temp_storage,
+                            event_time,
+                            diff * *r,
+                            |time| !until.less_equal(time),
+                            row_builder,
+                        )
+                        .collect::<Vec<_>>()
+                })
+                .map(|x| match x {
+                    Ok((row, event_time, diff)) => {
+                        // Copy the whole time, and re-populate event time.
+                        let mut time = time.clone();
+                        *time.event_time() = event_time;
+                        Ok((row, time, diff))
+                    }
+                    Err((e, event_time, diff)) => {
+                        // Copy the whole time, and re-populate event time.
+                        let mut time = time.clone();
+                        *time.event_time() = event_time;
+                        Err((e, time, diff))
+                    }
+                })
+                .collect::<Vec<_>>()
+        }
+    });
 
-        use differential_dataflow::AsCollection;
-        let ok_collection = oks.as_collection();
-        let new_err_collection = errs.as_collection();
-        let err_collection = err_collection.concat(&new_err_collection);
-        CollectionBundle::from_collections(ok_collection, err_collection)
-    }
+    use differential_dataflow::AsCollection;
+    let ok_collection = oks.as_collection();
+    let new_err_collection = errs.as_collection();
+    let err_collection = err_collection.concat(&new_err_collection);
+    CollectionBundle::from_collections(ok_collection, err_collection)
+}
 }

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -45,266 +45,264 @@ where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
 {
-    /// Renders `MirRelationExpr:Join` using dogs^3 delta query dataflows.
-    ///
-    /// The join is followed by the application of `map_filter_project`, whose
-    /// implementation will be pushed in to the join pipeline if at all possible.
-    pub fn render_delta_join(
-        &mut self,
-        inputs: Vec<CollectionBundle<G>>,
-        join_plan: DeltaJoinPlan,
-    ) -> CollectionBundle<G> {
-        // We create a new region to contain the dataflow paths for the delta join.
-        let (oks, errs) = self.scope.clone().region_named("Join(Delta)", |inner| {
-            // Collects error streams for the ambient scope.
-            let mut inner_errs = Vec::new();
+/// Renders `MirRelationExpr:Join` using dogs^3 delta query dataflows.
+///
+/// The join is followed by the application of `map_filter_project`, whose
+/// implementation will be pushed in to the join pipeline if at all possible.
+pub fn render_delta_join(
+    &mut self,
+    inputs: Vec<CollectionBundle<G>>,
+    join_plan: DeltaJoinPlan,
+) -> CollectionBundle<G> {
+    // We create a new region to contain the dataflow paths for the delta join.
+    let (oks, errs) = self.scope.clone().region_named("Join(Delta)", |inner| {
+        // Collects error streams for the ambient scope.
+        let mut inner_errs = Vec::new();
 
-            // Deduplicate the error streams of multiply used arrangements.
-            let mut err_dedup = BTreeSet::new();
+        // Deduplicate the error streams of multiply used arrangements.
+        let mut err_dedup = BTreeSet::new();
 
-            // Our plan is to iterate through each input relation, and attempt
-            // to find a plan that maximally uses existing keys (better: uses
-            // existing arrangements, to which we have access).
-            let mut join_results = Vec::new();
+        // Our plan is to iterate through each input relation, and attempt
+        // to find a plan that maximally uses existing keys (better: uses
+        // existing arrangements, to which we have access).
+        let mut join_results = Vec::new();
 
-            // First let's prepare the input arrangements we will need.
-            // This reduces redundant imports, and simplifies the dataflow structure.
-            // As the arrangements are all shared, it should not dramatically improve
-            // the efficiency, but the dataflow simplification is worth doing.
-            let mut arrangements = BTreeMap::new();
-            for path_plan in join_plan.path_plans.iter() {
-                for stage_plan in path_plan.stage_plans.iter() {
-                    let lookup_idx = stage_plan.lookup_relation;
-                    let lookup_key = stage_plan.lookup_key.clone();
-                    arrangements
-                        .entry((lookup_idx, lookup_key.clone()))
-                        .or_insert_with(|| {
-                            match inputs[lookup_idx]
-                                .arrangement(&lookup_key)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "Arrangement alarmingly absent!: {}, {:?}",
-                                        lookup_idx, lookup_key,
-                                    )
-                                }) {
-                                ArrangementFlavor::Local(oks, errs) => {
-                                    if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        inner_errs.push(
-                                            errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
-                                        );
-                                    }
-                                    Ok(oks.enter_region(inner))
+        // First let's prepare the input arrangements we will need.
+        // This reduces redundant imports, and simplifies the dataflow structure.
+        // As the arrangements are all shared, it should not dramatically improve
+        // the efficiency, but the dataflow simplification is worth doing.
+        let mut arrangements = BTreeMap::new();
+        for path_plan in join_plan.path_plans.iter() {
+            for stage_plan in path_plan.stage_plans.iter() {
+                let lookup_idx = stage_plan.lookup_relation;
+                let lookup_key = stage_plan.lookup_key.clone();
+                arrangements
+                    .entry((lookup_idx, lookup_key.clone()))
+                    .or_insert_with(|| {
+                        match inputs[lookup_idx]
+                            .arrangement(&lookup_key)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "Arrangement alarmingly absent!: {}, {:?}",
+                                    lookup_idx, lookup_key,
+                                )
+                            }) {
+                            ArrangementFlavor::Local(oks, errs) => {
+                                if err_dedup.insert((lookup_idx, lookup_key)) {
+                                    inner_errs.push(
+                                        errs.enter_region(inner).as_collection(|k, _v| k.clone()),
+                                    );
                                 }
-                                ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                    if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        inner_errs.push(
-                                            errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
-                                        );
-                                    }
-                                    Err(oks.enter_region(inner))
+                                Ok(oks.enter_region(inner))
+                            }
+                            ArrangementFlavor::Trace(_gid, oks, errs) => {
+                                if err_dedup.insert((lookup_idx, lookup_key)) {
+                                    inner_errs.push(
+                                        errs.enter_region(inner).as_collection(|k, _v| k.clone()),
+                                    );
+                                }
+                                Err(oks.enter_region(inner))
+                            }
+                        }
+                    });
+            }
+        }
+
+        for path_plan in join_plan.path_plans {
+            // Deconstruct the stages of the path plan.
+            let DeltaPathPlan {
+                source_relation,
+                initial_closure,
+                stage_plans,
+                final_closure,
+                source_key,
+            } = path_plan;
+
+            // This collection determines changes that result from updates inbound
+            // from `inputs[relation]` and reflects all strictly prior updates and
+            // concurrent updates from relations prior to `relation`.
+            let name = format!("delta path {}", source_relation);
+            let path_results = inner.clone().region_named(&name, |region| {
+                // The plan is to move through each relation, starting from `relation` and in the order
+                // indicated in `orders[relation]`. At each moment, we will have the columns from the
+                // subset of relations encountered so far, and we will have applied as much as we can
+                // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
+                // available columns.
+                //
+                // As we go, we will track the physical locations of each intended output column, as well
+                // as the locations of intermediate results from partial application of `map_filter_project`.
+                //
+                // Just before we apply the `lookup` function to perform a join, we will first use our
+                // available information to determine the filtering and logic that we can apply, and
+                // introduce that in to the `lookup` logic to cause it to happen in that operator.
+
+                // Collects error streams for the region scope. Concats before leaving.
+                let mut region_errs = Vec::with_capacity(inputs.len());
+
+                // Ensure this input is rendered, and extract its update stream.
+                let val = arrangements
+                    .get(&(source_relation, source_key))
+                    .expect("Arrangement promised by the planner is absent!");
+                let as_of = self.as_of_frontier.clone();
+                let update_stream = match val {
+                    Ok(local) => {
+                        let arranged = local.enter_region(region);
+                        let (update_stream, err_stream) = dispatch_build_update_stream_local(
+                            arranged,
+                            as_of,
+                            source_relation,
+                            initial_closure,
+                        );
+                        region_errs.push(err_stream);
+                        update_stream
+                    }
+                    Err(trace) => {
+                        let arranged = trace.enter_region(region);
+                        let (update_stream, err_stream) = dispatch_build_update_stream_trace(
+                            arranged,
+                            as_of,
+                            source_relation,
+                            initial_closure,
+                        );
+                        region_errs.push(err_stream);
+                        update_stream
+                    }
+                };
+                // Promote `time` to a datum element.
+                //
+                // The `half_join` operator manipulates as "data" a pair `(data, time)`,
+                // while tracking the initial time `init_time` separately and without
+                // modification. The initial value for both times is the initial time.
+                let mut update_stream = update_stream
+                    .inner
+                    .map(|(v, t, d)| ((v, t.clone()), t, d))
+                    .as_collection();
+
+                // Repeatedly update `update_stream` to reflect joins with more and more
+                // other relations, in the specified order.
+                for stage_plan in stage_plans {
+                    let DeltaStagePlan {
+                        lookup_relation,
+                        stream_key,
+                        stream_thinning,
+                        lookup_key,
+                        closure,
+                    } = stage_plan;
+
+                    // We require different logic based on the relative order of the two inputs.
+                    // If the `source` relation precedes the `lookup` relation, we present all
+                    // updates with less or equal `time`, and otherwise we present only updates
+                    // with strictly less `time`.
+                    //
+                    // We need to write the logic twice, as there are two types of arrangement
+                    // we might have: either dataflow-local or an imported trace.
+                    let (oks, errs) =
+                        match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
+                            Ok(local) => {
+                                if source_relation < lookup_relation {
+                                    dispatch_build_halfjoin_local(
+                                        update_stream,
+                                        local.enter_region(region),
+                                        stream_key,
+                                        stream_thinning,
+                                        |t1, t2| t1.le(t2),
+                                        closure,
+                                        self.shutdown_token.clone(),
+                                    )
+                                } else {
+                                    dispatch_build_halfjoin_local(
+                                        update_stream,
+                                        local.enter_region(region),
+                                        stream_key,
+                                        stream_thinning,
+                                        |t1, t2| t1.lt(t2),
+                                        closure,
+                                        self.shutdown_token.clone(),
+                                    )
                                 }
                             }
-                        });
+                            Err(trace) => {
+                                if source_relation < lookup_relation {
+                                    dispatch_build_halfjoin_trace(
+                                        update_stream,
+                                        trace.enter_region(region),
+                                        stream_key,
+                                        stream_thinning,
+                                        |t1, t2| t1.le(t2),
+                                        closure,
+                                        self.shutdown_token.clone(),
+                                    )
+                                } else {
+                                    dispatch_build_halfjoin_trace(
+                                        update_stream,
+                                        trace.enter_region(region),
+                                        stream_key,
+                                        stream_thinning,
+                                        |t1, t2| t1.lt(t2),
+                                        closure,
+                                        self.shutdown_token.clone(),
+                                    )
+                                }
+                            }
+                        };
+                    update_stream = oks;
+                    region_errs.push(errs);
                 }
-            }
 
-            for path_plan in join_plan.path_plans {
-                // Deconstruct the stages of the path plan.
-                let DeltaPathPlan {
-                    source_relation,
-                    initial_closure,
-                    stage_plans,
-                    final_closure,
-                    source_key,
-                } = path_plan;
+                // Delay updates as appropriate.
+                //
+                // The `half_join` operator maintains a time that we now discard (the `_`),
+                // and replace with the `time` that is maintained with the data. The former
+                // exists to pin a consistent total order on updates throughout the process,
+                // while allowing `time` to vary upwards as a result of actions on time.
+                let mut update_stream = update_stream
+                    .inner
+                    .map(|((row, time), _, diff)| (row, time, diff))
+                    .as_collection();
 
-                // This collection determines changes that result from updates inbound
-                // from `inputs[relation]` and reflects all strictly prior updates and
-                // concurrent updates from relations prior to `relation`.
-                let name = format!("delta path {}", source_relation);
-                let path_results = inner.clone().region_named(&name, |region| {
-                    // The plan is to move through each relation, starting from `relation` and in the order
-                    // indicated in `orders[relation]`. At each moment, we will have the columns from the
-                    // subset of relations encountered so far, and we will have applied as much as we can
-                    // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
-                    // available columns.
-                    //
-                    // As we go, we will track the physical locations of each intended output column, as well
-                    // as the locations of intermediate results from partial application of `map_filter_project`.
-                    //
-                    // Just before we apply the `lookup` function to perform a join, we will first use our
-                    // available information to determine the filtering and logic that we can apply, and
-                    // introduce that in to the `lookup` logic to cause it to happen in that operator.
+                // We have completed the join building, but may have work remaining.
+                // For example, we may have expressions not pushed down (e.g. literals)
+                // and projections that could not be applied (e.g. column repetition).
+                if let Some(final_closure) = final_closure {
+                    let (updates, errors) =
+                        update_stream.flat_map_fallible("DeltaJoinFinalization", {
+                            // Reuseable allocation for unpacking.
+                            let mut datums = DatumVec::new();
+                            move |row| {
+                                let binding = SharedRow::get();
+                                let mut row_builder = binding.borrow_mut();
+                                let temp_storage = RowArena::new();
+                                let mut datums_local = datums.borrow_with(&row);
+                                // TODO(mcsherry): re-use `row` allocation.
+                                final_closure
+                                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                                    .map_err(DataflowError::from)
+                                    .transpose()
+                            }
+                        });
 
-                    // Collects error streams for the region scope. Concats before leaving.
-                    let mut region_errs = Vec::with_capacity(inputs.len());
+                    update_stream = updates;
+                    region_errs.push(errors);
+                }
 
-                    // Ensure this input is rendered, and extract its update stream.
-                    let val = arrangements
-                        .get(&(source_relation, source_key))
-                        .expect("Arrangement promised by the planner is absent!");
-                    let as_of = self.as_of_frontier.clone();
-                    let update_stream = match val {
-                        Ok(local) => {
-                            let arranged = local.enter_region(region);
-                            let (update_stream, err_stream) = dispatch_build_update_stream_local(
-                                arranged,
-                                as_of,
-                                source_relation,
-                                initial_closure,
-                            );
-                            region_errs.push(err_stream);
-                            update_stream
-                        }
-                        Err(trace) => {
-                            let arranged = trace.enter_region(region);
-                            let (update_stream, err_stream) = dispatch_build_update_stream_trace(
-                                arranged,
-                                as_of,
-                                source_relation,
-                                initial_closure,
-                            );
-                            region_errs.push(err_stream);
-                            update_stream
-                        }
-                    };
-                    // Promote `time` to a datum element.
-                    //
-                    // The `half_join` operator manipulates as "data" a pair `(data, time)`,
-                    // while tracking the initial time `init_time` separately and without
-                    // modification. The initial value for both times is the initial time.
-                    let mut update_stream = update_stream
-                        .inner
-                        .map(|(v, t, d)| ((v, t.clone()), t, d))
-                        .as_collection();
+                inner_errs.push(
+                    differential_dataflow::collection::concatenate(region, region_errs)
+                        .leave_region(),
+                );
+                update_stream.leave_region()
+            });
 
-                    // Repeatedly update `update_stream` to reflect joins with more and more
-                    // other relations, in the specified order.
-                    for stage_plan in stage_plans {
-                        let DeltaStagePlan {
-                            lookup_relation,
-                            stream_key,
-                            stream_thinning,
-                            lookup_key,
-                            closure,
-                        } = stage_plan;
+            join_results.push(path_results);
+        }
 
-                        // We require different logic based on the relative order of the two inputs.
-                        // If the `source` relation precedes the `lookup` relation, we present all
-                        // updates with less or equal `time`, and otherwise we present only updates
-                        // with strictly less `time`.
-                        //
-                        // We need to write the logic twice, as there are two types of arrangement
-                        // we might have: either dataflow-local or an imported trace.
-                        let (oks, errs) =
-                            match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
-                                Ok(local) => {
-                                    if source_relation < lookup_relation {
-                                        dispatch_build_halfjoin_local(
-                                            update_stream,
-                                            local.enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.le(t2),
-                                            closure,
-                                            self.shutdown_token.clone(),
-                                        )
-                                    } else {
-                                        dispatch_build_halfjoin_local(
-                                            update_stream,
-                                            local.enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.lt(t2),
-                                            closure,
-                                            self.shutdown_token.clone(),
-                                        )
-                                    }
-                                }
-                                Err(trace) => {
-                                    if source_relation < lookup_relation {
-                                        dispatch_build_halfjoin_trace(
-                                            update_stream,
-                                            trace.enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.le(t2),
-                                            closure,
-                                            self.shutdown_token.clone(),
-                                        )
-                                    } else {
-                                        dispatch_build_halfjoin_trace(
-                                            update_stream,
-                                            trace.enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.lt(t2),
-                                            closure,
-                                            self.shutdown_token.clone(),
-                                        )
-                                    }
-                                }
-                            };
-                        update_stream = oks;
-                        region_errs.push(errs);
-                    }
-
-                    // Delay updates as appropriate.
-                    //
-                    // The `half_join` operator maintains a time that we now discard (the `_`),
-                    // and replace with the `time` that is maintained with the data. The former
-                    // exists to pin a consistent total order on updates throughout the process,
-                    // while allowing `time` to vary upwards as a result of actions on time.
-                    let mut update_stream = update_stream
-                        .inner
-                        .map(|((row, time), _, diff)| (row, time, diff))
-                        .as_collection();
-
-                    // We have completed the join building, but may have work remaining.
-                    // For example, we may have expressions not pushed down (e.g. literals)
-                    // and projections that could not be applied (e.g. column repetition).
-                    if let Some(final_closure) = final_closure {
-                        let (updates, errors) =
-                            update_stream.flat_map_fallible("DeltaJoinFinalization", {
-                                // Reuseable allocation for unpacking.
-                                let mut datums = DatumVec::new();
-                                move |row| {
-                                    let binding = SharedRow::get();
-                                    let mut row_builder = binding.borrow_mut();
-                                    let temp_storage = RowArena::new();
-                                    let mut datums_local = datums.borrow_with(&row);
-                                    // TODO(mcsherry): re-use `row` allocation.
-                                    final_closure
-                                        .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                                        .map_err(DataflowError::from)
-                                        .transpose()
-                                }
-                            });
-
-                        update_stream = updates;
-                        region_errs.push(errors);
-                    }
-
-                    inner_errs.push(
-                        differential_dataflow::collection::concatenate(region, region_errs)
-                            .leave_region(),
-                    );
-                    update_stream.leave_region()
-                });
-
-                join_results.push(path_results);
-            }
-
-            // Concatenate the results of each delta query as the accumulated results.
-            (
-                differential_dataflow::collection::concatenate(inner, join_results).leave_region(),
-                differential_dataflow::collection::concatenate(inner, inner_errs).leave_region(),
-            )
-        });
-        CollectionBundle::from_collections(oks, errs)
-    }
+        // Concatenate the results of each delta query as the accumulated results.
+        (
+            differential_dataflow::collection::concatenate(inner, join_results).leave_region(),
+            differential_dataflow::collection::concatenate(inner, inner_errs).leave_region(),
+        )
+    });
+    CollectionBundle::from_collections(oks, errs)
+}
 }
 
 /// Dispatches half-join construction according to arrangement type specialization.

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -29,7 +29,6 @@ use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::container::columnation::Columnation;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{Map, OkErr};
-use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
@@ -46,21 +45,24 @@ use crate::typedefs::{RowAgent, RowEnter, RowRowAgent, RowRowEnter};
 /// The join is followed by the application of `map_filter_project`, whose
 /// implementation will be pushed in to the join pipeline if at all possible.
 pub fn render_delta_join<C: Context>(
-    ctx: &C,
+    ctx: &mut C,
     inputs: Vec<CollectionBundle<C::Scope>>,
     join_plan: DeltaJoinPlan,
 ) -> CollectionBundle<C::Scope> {
     // We create a new region to contain the dataflow paths for the delta join.
-    ctx.scope().clone().region_named("Join(Delta)", |inner| {
-        render_delta_join_inner(ctx, inputs, join_plan, inner)
+    ctx.region("Join(Delta)", |inner| {
+        let inputs = inputs
+            .into_iter()
+            .map(|i| i.enter_region(inner.scope()))
+            .collect();
+        render_delta_join_inner(inner, inputs, join_plan).leave_region()
     })
 }
 
 fn render_delta_join_inner<C: Context>(
-    ctx: &C,
+    ctx: &mut C,
     inputs: Vec<CollectionBundle<C::Scope>>,
     join_plan: DeltaJoinPlan,
-    inner: &mut Child<C::Scope, C::Timestamp>,
 ) -> CollectionBundle<C::Scope> {
     // Collects error streams.
     let mut errors = Vec::new();
@@ -73,78 +75,67 @@ fn render_delta_join_inner<C: Context>(
     // existing arrangements, to which we have access).
     let mut join_results = Vec::new();
 
-    // First let's prepare the input arrangements we will need.
-    // This reduces redundant imports, and simplifies the dataflow structure.
-    // As the arrangements are all shared, it should not dramatically improve
-    // the efficiency, but the dataflow simplification is worth doing.
-    let mut arrangements = BTreeMap::new();
-    for path_plan in join_plan.path_plans.iter() {
-        for stage_plan in path_plan.stage_plans.iter() {
-            let lookup_idx = stage_plan.lookup_relation;
-            let lookup_key = stage_plan.lookup_key.clone();
-            arrangements
-                .entry((lookup_idx, lookup_key.clone()))
-                .or_insert_with(|| {
-                    match inputs[lookup_idx]
-                        .arrangement(&lookup_key)
-                        .unwrap_or_else(|| {
-                            panic!(
-                                "Arrangement alarmingly absent!: {}, {:?}",
-                                lookup_idx, lookup_key,
-                            )
-                        }) {
-                        ArrangementFlavor::Local(oks, errs) => {
-                            if err_dedup.insert((lookup_idx, lookup_key)) {
-                                errors.push(
-                                    errs.enter_region(inner).as_collection(|k, _v| k.clone()),
-                                );
-                            }
-                            Ok(oks.enter_region(inner))
-                        }
-                        ArrangementFlavor::Trace(_gid, oks, errs) => {
-                            if err_dedup.insert((lookup_idx, lookup_key)) {
-                                errors.push(
-                                    errs.enter_region(inner).as_collection(|k, _v| k.clone()),
-                                );
-                            }
-                            Err(oks.enter_region(inner))
-                        }
-                    }
-                });
-        }
-    }
+    let expect_arrangement = |(relation, key): &(usize, Vec<_>)| {
+        inputs[*relation]
+            .arrangement(key)
+            .unwrap_or_else(|| panic!("Arrangement alarmingly absent!: {}, {:?}", relation, key))
+    };
 
     for path_plan in join_plan.path_plans {
         // This collection determines changes that result from updates inbound
         // from `inputs[relation]` and reflects all strictly prior updates and
         // concurrent updates from relations prior to `relation`.
         let name = format!("delta path {}", path_plan.source_relation);
-        let (oks, errs) = inner.clone().region_named(&name, |region| {
-            render_delta_path::<_, Child<C::Scope, _>>(ctx, &arrangements, path_plan, region)
-        });
+        ctx.region(&name, |region| {
+            // Collect and import the arrangements needed by this path.
+            let mut arrangements = BTreeMap::new();
+            let keys = path_plan
+                .stage_plans
+                .iter()
+                .map(|p| (p.lookup_relation, p.lookup_key.clone()))
+                .chain([(path_plan.source_relation, path_plan.source_key.clone())]);
+            for key in keys {
+                arrangements
+                    .entry(key.clone())
+                    .or_insert_with(|| match expect_arrangement(&key) {
+                        ArrangementFlavor::Local(oks, errs) => {
+                            if err_dedup.insert(key) {
+                                errors.push(errs.as_collection(|k, _v| k.clone()));
+                            }
+                            Ok(oks.enter_region(region.scope()))
+                        }
+                        ArrangementFlavor::Trace(_gid, oks, errs) => {
+                            if err_dedup.insert(key) {
+                                errors.push(errs.as_collection(|k, _v| k.clone()));
+                            }
+                            Err(oks.enter_region(region.scope()))
+                        }
+                    });
+            }
 
-        join_results.push(oks);
-        errors.push(errs);
+            let (oks, errs) = render_delta_path(region, arrangements, path_plan);
+            join_results.push(oks.leave_region());
+            errors.push(errs.leave_region());
+        });
     }
 
     // Concatenate the results of each delta query as the accumulated results.
-    let oks = differential_dataflow::collection::concatenate(inner, join_results);
-    let errs = differential_dataflow::collection::concatenate(inner, errors);
-    CollectionBundle::from_collections(oks.leave_region(), errs.leave_region())
+    let oks = differential_dataflow::collection::concatenate(ctx.scope_mut(), join_results);
+    let errs = differential_dataflow::collection::concatenate(ctx.scope_mut(), errors);
+    CollectionBundle::from_collections(oks, errs)
 }
 
-fn render_delta_path<C: Context, S>(
-    ctx: &C,
-    arrangements: &BTreeMap<
+fn render_delta_path<C: Context>(
+    ctx: &mut C,
+    arrangements: BTreeMap<
         (usize, Vec<MirScalarExpr>),
-        Result<SpecializedArrangement<S>, SpecializedArrangementImport<S>>,
+        Result<SpecializedArrangement<C::Scope>, SpecializedArrangementImport<C::Scope>>,
     >,
     path_plan: DeltaPathPlan,
-    region: &mut Child<S, C::Timestamp>,
-) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
-where
-    S: Scope<Timestamp = C::Timestamp>,
-{
+) -> (
+    Collection<C::Scope, Row, Diff>,
+    Collection<C::Scope, DataflowError, Diff>,
+) {
     // The plan is to move through each relation, starting from `relation` and in the order
     // indicated in `orders[relation]`. At each moment, we will have the columns from the
     // subset of relations encountered so far, and we will have applied as much as we can
@@ -172,28 +163,19 @@ where
     // Ensure this input is rendered, and extract its update stream.
     let val = arrangements
         .get(&(source_relation, source_key))
-        .expect("Arrangement promised by the planner is absent!");
+        .expect("Arrangement promised by the planner is absent!")
+        .clone();
     let as_of = ctx.as_of().clone();
     let update_stream = match val {
         Ok(local) => {
-            let arranged = local.enter_region(region);
-            let (update_stream, err_stream) = dispatch_build_update_stream_local(
-                arranged,
-                as_of,
-                source_relation,
-                initial_closure,
-            );
+            let (update_stream, err_stream) =
+                dispatch_build_update_stream_local(local, as_of, source_relation, initial_closure);
             errors.push(err_stream);
             update_stream
         }
         Err(trace) => {
-            let arranged = trace.enter_region(region);
-            let (update_stream, err_stream) = dispatch_build_update_stream_trace(
-                arranged,
-                as_of,
-                source_relation,
-                initial_closure,
-            );
+            let (update_stream, err_stream) =
+                dispatch_build_update_stream_trace(trace, as_of, source_relation, initial_closure);
             errors.push(err_stream);
             update_stream
         }
@@ -226,12 +208,16 @@ where
         //
         // We need to write the logic twice, as there are two types of arrangement
         // we might have: either dataflow-local or an imported trace.
-        let (oks, errs) = match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
+        let val = arrangements
+            .get(&(lookup_relation, lookup_key))
+            .expect("Arrangement promised by the planner is absent!")
+            .clone();
+        let (oks, errs) = match val {
             Ok(local) => {
                 if source_relation < lookup_relation {
                     dispatch_build_halfjoin_local(
                         update_stream,
-                        local.enter_region(region),
+                        local,
                         stream_key,
                         stream_thinning,
                         |t1, t2| t1.le(t2),
@@ -241,7 +227,7 @@ where
                 } else {
                     dispatch_build_halfjoin_local(
                         update_stream,
-                        local.enter_region(region),
+                        local,
                         stream_key,
                         stream_thinning,
                         |t1, t2| t1.lt(t2),
@@ -254,7 +240,7 @@ where
                 if source_relation < lookup_relation {
                     dispatch_build_halfjoin_trace(
                         update_stream,
-                        trace.enter_region(region),
+                        trace,
                         stream_key,
                         stream_thinning,
                         |t1, t2| t1.le(t2),
@@ -264,7 +250,7 @@ where
                 } else {
                     dispatch_build_halfjoin_trace(
                         update_stream,
-                        trace.enter_region(region),
+                        trace,
                         stream_key,
                         stream_thinning,
                         |t1, t2| t1.lt(t2),
@@ -314,8 +300,8 @@ where
     }
 
     (
-        update_stream.leave_region(),
-        differential_dataflow::collection::concatenate(region, errors).leave_region(),
+        update_stream,
+        differential_dataflow::collection::concatenate(ctx.scope_mut(), errors),
     )
 }
 

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -29,6 +29,7 @@ use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::container::columnation::Columnation;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{Map, OkErr};
+use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
@@ -50,253 +51,272 @@ pub fn render_delta_join<C: Context>(
     join_plan: DeltaJoinPlan,
 ) -> CollectionBundle<C::Scope> {
     // We create a new region to contain the dataflow paths for the delta join.
-    let (oks, errs) = ctx.scope().clone().region_named("Join(Delta)", |inner| {
-        // Collects error streams for the ambient scope.
-        let mut inner_errs = Vec::new();
+    ctx.scope().clone().region_named("Join(Delta)", |inner| {
+        render_delta_join_inner(ctx, inputs, join_plan, inner)
+    })
+}
 
-        // Deduplicate the error streams of multiply used arrangements.
-        let mut err_dedup = BTreeSet::new();
+fn render_delta_join_inner<C: Context>(
+    ctx: &C,
+    inputs: Vec<CollectionBundle<C::Scope>>,
+    join_plan: DeltaJoinPlan,
+    inner: &mut Child<C::Scope, C::Timestamp>,
+) -> CollectionBundle<C::Scope> {
+    // Collects error streams.
+    let mut errors = Vec::new();
 
-        // Our plan is to iterate through each input relation, and attempt
-        // to find a plan that maximally uses existing keys (better: uses
-        // existing arrangements, to which we have access).
-        let mut join_results = Vec::new();
+    // Deduplicate the error streams of multiply used arrangements.
+    let mut err_dedup = BTreeSet::new();
 
-        // First let's prepare the input arrangements we will need.
-        // This reduces redundant imports, and simplifies the dataflow structure.
-        // As the arrangements are all shared, it should not dramatically improve
-        // the efficiency, but the dataflow simplification is worth doing.
-        let mut arrangements = BTreeMap::new();
-        for path_plan in join_plan.path_plans.iter() {
-            for stage_plan in path_plan.stage_plans.iter() {
-                let lookup_idx = stage_plan.lookup_relation;
-                let lookup_key = stage_plan.lookup_key.clone();
-                arrangements
-                    .entry((lookup_idx, lookup_key.clone()))
-                    .or_insert_with(|| {
-                        match inputs[lookup_idx]
-                            .arrangement(&lookup_key)
-                            .unwrap_or_else(|| {
-                                panic!(
-                                    "Arrangement alarmingly absent!: {}, {:?}",
-                                    lookup_idx, lookup_key,
-                                )
-                            }) {
-                            ArrangementFlavor::Local(oks, errs) => {
-                                if err_dedup.insert((lookup_idx, lookup_key)) {
-                                    inner_errs.push(
-                                        errs.enter_region(inner).as_collection(|k, _v| k.clone()),
-                                    );
-                                }
-                                Ok(oks.enter_region(inner))
+    // Our plan is to iterate through each input relation, and attempt
+    // to find a plan that maximally uses existing keys (better: uses
+    // existing arrangements, to which we have access).
+    let mut join_results = Vec::new();
+
+    // First let's prepare the input arrangements we will need.
+    // This reduces redundant imports, and simplifies the dataflow structure.
+    // As the arrangements are all shared, it should not dramatically improve
+    // the efficiency, but the dataflow simplification is worth doing.
+    let mut arrangements = BTreeMap::new();
+    for path_plan in join_plan.path_plans.iter() {
+        for stage_plan in path_plan.stage_plans.iter() {
+            let lookup_idx = stage_plan.lookup_relation;
+            let lookup_key = stage_plan.lookup_key.clone();
+            arrangements
+                .entry((lookup_idx, lookup_key.clone()))
+                .or_insert_with(|| {
+                    match inputs[lookup_idx]
+                        .arrangement(&lookup_key)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "Arrangement alarmingly absent!: {}, {:?}",
+                                lookup_idx, lookup_key,
+                            )
+                        }) {
+                        ArrangementFlavor::Local(oks, errs) => {
+                            if err_dedup.insert((lookup_idx, lookup_key)) {
+                                errors.push(
+                                    errs.enter_region(inner).as_collection(|k, _v| k.clone()),
+                                );
                             }
-                            ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                if err_dedup.insert((lookup_idx, lookup_key)) {
-                                    inner_errs.push(
-                                        errs.enter_region(inner).as_collection(|k, _v| k.clone()),
-                                    );
-                                }
-                                Err(oks.enter_region(inner))
-                            }
+                            Ok(oks.enter_region(inner))
                         }
-                    });
-            }
+                        ArrangementFlavor::Trace(_gid, oks, errs) => {
+                            if err_dedup.insert((lookup_idx, lookup_key)) {
+                                errors.push(
+                                    errs.enter_region(inner).as_collection(|k, _v| k.clone()),
+                                );
+                            }
+                            Err(oks.enter_region(inner))
+                        }
+                    }
+                });
         }
+    }
 
-        for path_plan in join_plan.path_plans {
-            // Deconstruct the stages of the path plan.
-            let DeltaPathPlan {
+    for path_plan in join_plan.path_plans {
+        // This collection determines changes that result from updates inbound
+        // from `inputs[relation]` and reflects all strictly prior updates and
+        // concurrent updates from relations prior to `relation`.
+        let name = format!("delta path {}", path_plan.source_relation);
+        let (oks, errs) = inner.clone().region_named(&name, |region| {
+            render_delta_path::<_, Child<C::Scope, _>>(ctx, &arrangements, path_plan, region)
+        });
+
+        join_results.push(oks);
+        errors.push(errs);
+    }
+
+    // Concatenate the results of each delta query as the accumulated results.
+    let oks = differential_dataflow::collection::concatenate(inner, join_results);
+    let errs = differential_dataflow::collection::concatenate(inner, errors);
+    CollectionBundle::from_collections(oks.leave_region(), errs.leave_region())
+}
+
+fn render_delta_path<C: Context, S>(
+    ctx: &C,
+    arrangements: &BTreeMap<
+        (usize, Vec<MirScalarExpr>),
+        Result<SpecializedArrangement<S>, SpecializedArrangementImport<S>>,
+    >,
+    path_plan: DeltaPathPlan,
+    region: &mut Child<S, C::Timestamp>,
+) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
+where
+    S: Scope<Timestamp = C::Timestamp>,
+{
+    // The plan is to move through each relation, starting from `relation` and in the order
+    // indicated in `orders[relation]`. At each moment, we will have the columns from the
+    // subset of relations encountered so far, and we will have applied as much as we can
+    // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
+    // available columns.
+    //
+    // As we go, we will track the physical locations of each intended output column, as well
+    // as the locations of intermediate results from partial application of `map_filter_project`.
+    //
+    // Just before we apply the `lookup` function to perform a join, we will first use our
+    // available information to determine the filtering and logic that we can apply, and
+    // introduce that in to the `lookup` logic to cause it to happen in that operator.
+
+    let DeltaPathPlan {
+        source_relation,
+        initial_closure,
+        stage_plans,
+        final_closure,
+        source_key,
+    } = path_plan;
+
+    // Collects error streams. Concats before leaving.
+    let mut errors = Vec::new();
+
+    // Ensure this input is rendered, and extract its update stream.
+    let val = arrangements
+        .get(&(source_relation, source_key))
+        .expect("Arrangement promised by the planner is absent!");
+    let as_of = ctx.as_of().clone();
+    let update_stream = match val {
+        Ok(local) => {
+            let arranged = local.enter_region(region);
+            let (update_stream, err_stream) = dispatch_build_update_stream_local(
+                arranged,
+                as_of,
                 source_relation,
                 initial_closure,
-                stage_plans,
-                final_closure,
-                source_key,
-            } = path_plan;
+            );
+            errors.push(err_stream);
+            update_stream
+        }
+        Err(trace) => {
+            let arranged = trace.enter_region(region);
+            let (update_stream, err_stream) = dispatch_build_update_stream_trace(
+                arranged,
+                as_of,
+                source_relation,
+                initial_closure,
+            );
+            errors.push(err_stream);
+            update_stream
+        }
+    };
+    // Promote `time` to a datum element.
+    //
+    // The `half_join` operator manipulates as "data" a pair `(data, time)`,
+    // while tracking the initial time `init_time` separately and without
+    // modification. The initial value for both times is the initial time.
+    let mut update_stream = update_stream
+        .inner
+        .map(|(v, t, d)| ((v, t.clone()), t, d))
+        .as_collection();
 
-            // This collection determines changes that result from updates inbound
-            // from `inputs[relation]` and reflects all strictly prior updates and
-            // concurrent updates from relations prior to `relation`.
-            let name = format!("delta path {}", source_relation);
-            let path_results = inner.clone().region_named(&name, |region| {
-                // The plan is to move through each relation, starting from `relation` and in the order
-                // indicated in `orders[relation]`. At each moment, we will have the columns from the
-                // subset of relations encountered so far, and we will have applied as much as we can
-                // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
-                // available columns.
-                //
-                // As we go, we will track the physical locations of each intended output column, as well
-                // as the locations of intermediate results from partial application of `map_filter_project`.
-                //
-                // Just before we apply the `lookup` function to perform a join, we will first use our
-                // available information to determine the filtering and logic that we can apply, and
-                // introduce that in to the `lookup` logic to cause it to happen in that operator.
+    // Repeatedly update `update_stream` to reflect joins with more and more
+    // other relations, in the specified order.
+    for stage_plan in stage_plans {
+        let DeltaStagePlan {
+            lookup_relation,
+            stream_key,
+            stream_thinning,
+            lookup_key,
+            closure,
+        } = stage_plan;
 
-                // Collects error streams for the region scope. Concats before leaving.
-                let mut region_errs = Vec::with_capacity(inputs.len());
-
-                // Ensure this input is rendered, and extract its update stream.
-                let val = arrangements
-                    .get(&(source_relation, source_key))
-                    .expect("Arrangement promised by the planner is absent!");
-                let as_of = ctx.as_of().clone();
-                let update_stream = match val {
-                    Ok(local) => {
-                        let arranged = local.enter_region(region);
-                        let (update_stream, err_stream) = dispatch_build_update_stream_local(
-                            arranged,
-                            as_of,
-                            source_relation,
-                            initial_closure,
-                        );
-                        region_errs.push(err_stream);
-                        update_stream
-                    }
-                    Err(trace) => {
-                        let arranged = trace.enter_region(region);
-                        let (update_stream, err_stream) = dispatch_build_update_stream_trace(
-                            arranged,
-                            as_of,
-                            source_relation,
-                            initial_closure,
-                        );
-                        region_errs.push(err_stream);
-                        update_stream
-                    }
-                };
-                // Promote `time` to a datum element.
-                //
-                // The `half_join` operator manipulates as "data" a pair `(data, time)`,
-                // while tracking the initial time `init_time` separately and without
-                // modification. The initial value for both times is the initial time.
-                let mut update_stream = update_stream
-                    .inner
-                    .map(|(v, t, d)| ((v, t.clone()), t, d))
-                    .as_collection();
-
-                // Repeatedly update `update_stream` to reflect joins with more and more
-                // other relations, in the specified order.
-                for stage_plan in stage_plans {
-                    let DeltaStagePlan {
-                        lookup_relation,
+        // We require different logic based on the relative order of the two inputs.
+        // If the `source` relation precedes the `lookup` relation, we present all
+        // updates with less or equal `time`, and otherwise we present only updates
+        // with strictly less `time`.
+        //
+        // We need to write the logic twice, as there are two types of arrangement
+        // we might have: either dataflow-local or an imported trace.
+        let (oks, errs) = match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
+            Ok(local) => {
+                if source_relation < lookup_relation {
+                    dispatch_build_halfjoin_local(
+                        update_stream,
+                        local.enter_region(region),
                         stream_key,
                         stream_thinning,
-                        lookup_key,
+                        |t1, t2| t1.le(t2),
                         closure,
-                    } = stage_plan;
-
-                    // We require different logic based on the relative order of the two inputs.
-                    // If the `source` relation precedes the `lookup` relation, we present all
-                    // updates with less or equal `time`, and otherwise we present only updates
-                    // with strictly less `time`.
-                    //
-                    // We need to write the logic twice, as there are two types of arrangement
-                    // we might have: either dataflow-local or an imported trace.
-                    let (oks, errs) =
-                        match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
-                            Ok(local) => {
-                                if source_relation < lookup_relation {
-                                    dispatch_build_halfjoin_local(
-                                        update_stream,
-                                        local.enter_region(region),
-                                        stream_key,
-                                        stream_thinning,
-                                        |t1, t2| t1.le(t2),
-                                        closure,
-                                        ctx.shutdown_token().clone(),
-                                    )
-                                } else {
-                                    dispatch_build_halfjoin_local(
-                                        update_stream,
-                                        local.enter_region(region),
-                                        stream_key,
-                                        stream_thinning,
-                                        |t1, t2| t1.lt(t2),
-                                        closure,
-                                        ctx.shutdown_token().clone(),
-                                    )
-                                }
-                            }
-                            Err(trace) => {
-                                if source_relation < lookup_relation {
-                                    dispatch_build_halfjoin_trace(
-                                        update_stream,
-                                        trace.enter_region(region),
-                                        stream_key,
-                                        stream_thinning,
-                                        |t1, t2| t1.le(t2),
-                                        closure,
-                                        ctx.shutdown_token().clone(),
-                                    )
-                                } else {
-                                    dispatch_build_halfjoin_trace(
-                                        update_stream,
-                                        trace.enter_region(region),
-                                        stream_key,
-                                        stream_thinning,
-                                        |t1, t2| t1.lt(t2),
-                                        closure,
-                                        ctx.shutdown_token().clone(),
-                                    )
-                                }
-                            }
-                        };
-                    update_stream = oks;
-                    region_errs.push(errs);
+                        ctx.shutdown_token().clone(),
+                    )
+                } else {
+                    dispatch_build_halfjoin_local(
+                        update_stream,
+                        local.enter_region(region),
+                        stream_key,
+                        stream_thinning,
+                        |t1, t2| t1.lt(t2),
+                        closure,
+                        ctx.shutdown_token().clone(),
+                    )
                 }
-
-                // Delay updates as appropriate.
-                //
-                // The `half_join` operator maintains a time that we now discard (the `_`),
-                // and replace with the `time` that is maintained with the data. The former
-                // exists to pin a consistent total order on updates throughout the process,
-                // while allowing `time` to vary upwards as a result of actions on time.
-                let mut update_stream = update_stream
-                    .inner
-                    .map(|((row, time), _, diff)| (row, time, diff))
-                    .as_collection();
-
-                // We have completed the join building, but may have work remaining.
-                // For example, we may have expressions not pushed down (e.g. literals)
-                // and projections that could not be applied (e.g. column repetition).
-                if let Some(final_closure) = final_closure {
-                    let (updates, errors) =
-                        update_stream.flat_map_fallible("DeltaJoinFinalization", {
-                            // Reuseable allocation for unpacking.
-                            let mut datums = DatumVec::new();
-                            move |row| {
-                                let binding = SharedRow::get();
-                                let mut row_builder = binding.borrow_mut();
-                                let temp_storage = RowArena::new();
-                                let mut datums_local = datums.borrow_with(&row);
-                                // TODO(mcsherry): re-use `row` allocation.
-                                final_closure
-                                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                                    .map_err(DataflowError::from)
-                                    .transpose()
-                            }
-                        });
-
-                    update_stream = updates;
-                    region_errs.push(errors);
+            }
+            Err(trace) => {
+                if source_relation < lookup_relation {
+                    dispatch_build_halfjoin_trace(
+                        update_stream,
+                        trace.enter_region(region),
+                        stream_key,
+                        stream_thinning,
+                        |t1, t2| t1.le(t2),
+                        closure,
+                        ctx.shutdown_token().clone(),
+                    )
+                } else {
+                    dispatch_build_halfjoin_trace(
+                        update_stream,
+                        trace.enter_region(region),
+                        stream_key,
+                        stream_thinning,
+                        |t1, t2| t1.lt(t2),
+                        closure,
+                        ctx.shutdown_token().clone(),
+                    )
                 }
+            }
+        };
+        update_stream = oks;
+        errors.push(errs);
+    }
 
-                inner_errs.push(
-                    differential_dataflow::collection::concatenate(region, region_errs)
-                        .leave_region(),
-                );
-                update_stream.leave_region()
-            });
+    // Delay updates as appropriate.
+    //
+    // The `half_join` operator maintains a time that we now discard (the `_`),
+    // and replace with the `time` that is maintained with the data. The former
+    // exists to pin a consistent total order on updates throughout the process,
+    // while allowing `time` to vary upwards as a result of actions on time.
+    let mut update_stream = update_stream
+        .inner
+        .map(|((row, time), _, diff)| (row, time, diff))
+        .as_collection();
 
-            join_results.push(path_results);
-        }
+    // We have completed the join building, but may have work remaining.
+    // For example, we may have expressions not pushed down (e.g. literals)
+    // and projections that could not be applied (e.g. column repetition).
+    if let Some(final_closure) = final_closure {
+        let (updates, errs) = update_stream.flat_map_fallible("DeltaJoinFinalization", {
+            // Reuseable allocation for unpacking.
+            let mut datums = DatumVec::new();
+            move |row| {
+                let binding = SharedRow::get();
+                let mut row_builder = binding.borrow_mut();
+                let temp_storage = RowArena::new();
+                let mut datums_local = datums.borrow_with(&row);
+                // TODO(mcsherry): re-use `row` allocation.
+                final_closure
+                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                    .map_err(DataflowError::from)
+                    .transpose()
+            }
+        });
 
-        // Concatenate the results of each delta query as the accumulated results.
-        (
-            differential_dataflow::collection::concatenate(inner, join_results).leave_region(),
-            differential_dataflow::collection::concatenate(inner, inner_errs).leave_region(),
-        )
-    });
-    CollectionBundle::from_collections(oks, errs)
+        update_stream = updates;
+        errors.push(errs);
+    }
+
+    (
+        update_stream.leave_region(),
+        differential_dataflow::collection::concatenate(region, errors).leave_region(),
+    )
 }
 
 /// Dispatches half-join construction according to arrangement type specialization.

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -27,7 +27,6 @@ use mz_timely_util::operator::CollectionExt;
 use timely::container::columnation::Columnation;
 use timely::dataflow::operators::OkErr;
 use timely::dataflow::Scope;
-use timely::dataflow::scopes::Child;
 use timely::progress::timestamp::{Refines, Timestamp};
 
 use crate::extensions::arrange::MzArrange;
@@ -137,20 +136,23 @@ where
 }
 
 pub(crate) fn render_join<C: Context>(
-    ctx: &C,
+    ctx: &mut C,
     inputs: Vec<CollectionBundle<C::Scope>>,
     linear_plan: LinearJoinPlan,
 ) -> CollectionBundle<C::Scope> {
-    ctx.scope().clone().region_named("Join(Linear)", |inner| {
-        render_join_inner(ctx, inputs, linear_plan, inner)
+    ctx.region("Join(Linear)", |inner| {
+        let inputs = inputs
+            .into_iter()
+            .map(|i| i.enter_region(inner.scope()))
+            .collect();
+        render_join_inner(inner, inputs, linear_plan).leave_region()
     })
 }
 
 fn render_join_inner<C: Context>(
-    ctx: &C,
+    ctx: &mut C,
     inputs: Vec<CollectionBundle<C::Scope>>,
     linear_plan: LinearJoinPlan,
-    inner: &mut Child<C::Scope, C::Timestamp>,
 ) -> CollectionBundle<C::Scope> {
     // Collect all error streams, and concatenate them at the end.
     let mut errors = Vec::new();
@@ -166,20 +168,19 @@ fn render_join_inner<C: Context>(
     // We can use an arrangement if it exists and an initial closure does not.
     let mut joined = match (arrangement, linear_plan.initial_closure) {
         (Some(ArrangementFlavor::Local(oks, errs)), None) => {
-            errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
-            JoinedFlavor::Local(oks.enter_region(inner))
+            errors.push(errs.as_collection(|k, _v| k.clone()));
+            JoinedFlavor::Local(oks)
         }
         (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
-            errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
-            JoinedFlavor::Trace(oks.enter_region(inner))
+            errors.push(errs.as_collection(|k, _v| k.clone()));
+            JoinedFlavor::Trace(oks)
         }
         (_, initial_closure) => {
             // TODO: extract closure from the first stage in the join plan, should it exist.
             // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
-            let (joined, errs) = inputs[linear_plan.source_relation]
+            let (mut joined, errs) = inputs[linear_plan.source_relation]
                 .as_specific_collection(linear_plan.source_key.as_deref());
-            errors.push(errs.enter_region(inner));
-            let mut joined = joined.enter_region(inner);
+            errors.push(errs);
 
             // In the current code this should always be `None`, but we have this here should
             // we change that and want to know what we should be doing.
@@ -217,7 +218,7 @@ fn render_join_inner<C: Context>(
         let stream = differential_join(
             ctx,
             joined,
-            inputs[stage_plan.lookup_relation].enter_region(inner),
+            inputs[stage_plan.lookup_relation].clone(),
             stage_plan,
             &mut errors,
         );
@@ -253,20 +254,19 @@ fn render_join_inner<C: Context>(
         // Return joined results and all produced errors collected together.
         CollectionBundle::from_collections(
             joined,
-            differential_dataflow::collection::concatenate(inner, errors),
+            differential_dataflow::collection::concatenate(ctx.scope_mut(), errors),
         )
     } else {
         panic!("Unexpectedly arranged join output");
     }
-    .leave_region()
 }
 
 /// Looks up the arrangement for the next input and joins it to the arranged
 /// version of the join of previous inputs.
-fn differential_join<C, S>(
+fn differential_join<C: Context>(
     ctx: &C,
-    mut joined: JoinedFlavor<S>,
-    lookup_relation: CollectionBundle<S>,
+    mut joined: JoinedFlavor<C::Scope>,
+    lookup_relation: CollectionBundle<C::Scope>,
     LinearStagePlan {
         stream_key,
         stream_thinning,
@@ -274,12 +274,8 @@ fn differential_join<C, S>(
         closure,
         lookup_relation: _,
     }: LinearStagePlan,
-    errors: &mut Vec<Collection<S, DataflowError, Diff>>,
-) -> Collection<S, Row, Diff>
-where
-    C: Context,
-    S: Scope<Timestamp = C::Timestamp>,
-{
+    errors: &mut Vec<Collection<C::Scope, DataflowError, Diff>>,
+) -> Collection<C::Scope, Row, Diff> {
     // If we have only a streamed collection, we must first form an arrangement.
     if let JoinedFlavor::Collection(stream) = joined {
         let (keyed, errs) = stream.map_fallible("LinearJoinKeyPreparation", {
@@ -329,7 +325,7 @@ where
             ArrangementFlavor::Local(oks, errs1) => {
                 let (oks, errs2) = match (local, oks) {
                     (A::RowUnit(prev_keyed), A::RowUnit(next_input)) => {
-                        differential_join_inner::<_, _, RowAgent<_, _>, RowAgent<_, _>>(
+                        differential_join_inner::<_, RowAgent<_, _>, RowAgent<_, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -340,7 +336,7 @@ where
                         )
                     }
                     (A::RowUnit(prev_keyed), A::RowRow(next_input)) => {
-                        differential_join_inner::<_, _, RowAgent<_, _>, RowRowAgent<_, _>>(
+                        differential_join_inner::<_, RowAgent<_, _>, RowRowAgent<_, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -351,7 +347,7 @@ where
                         )
                     }
                     (A::RowRow(prev_keyed), A::RowUnit(next_input)) => {
-                        differential_join_inner::<_, _, RowRowAgent<_, _>, RowAgent<_, _>>(
+                        differential_join_inner::<_, RowRowAgent<_, _>, RowAgent<_, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -362,7 +358,7 @@ where
                         )
                     }
                     (A::RowRow(prev_keyed), A::RowRow(next_input)) => {
-                        differential_join_inner::<_, _, RowRowAgent<_, _>, RowRowAgent<_, _>>(
+                        differential_join_inner::<_, RowRowAgent<_, _>, RowRowAgent<_, _>>(
                             ctx, prev_keyed, next_input, None, None, None, closure,
                         )
                     }
@@ -375,7 +371,7 @@ where
             ArrangementFlavor::Trace(_gid, oks, errs1) => {
                 let (oks, errs2) = match (local, oks) {
                     (A::RowUnit(prev_keyed), I::RowUnit(next_input)) => {
-                        differential_join_inner::<_, _, RowAgent<_, _>, RowEnter<_, _, _>>(
+                        differential_join_inner::<_, RowAgent<_, _>, RowEnter<_, _, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -386,7 +382,7 @@ where
                         )
                     }
                     (A::RowUnit(prev_keyed), I::RowRow(next_input)) => {
-                        differential_join_inner::<_, _, RowAgent<_, _>, RowRowEnter<_, _, _>>(
+                        differential_join_inner::<_, RowAgent<_, _>, RowRowEnter<_, _, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -397,7 +393,7 @@ where
                         )
                     }
                     (A::RowRow(prev_keyed), I::RowUnit(next_input)) => {
-                        differential_join_inner::<_, _, RowRowAgent<_, _>, RowEnter<_, _, _>>(
+                        differential_join_inner::<_, RowRowAgent<_, _>, RowEnter<_, _, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -408,7 +404,7 @@ where
                         )
                     }
                     (A::RowRow(prev_keyed), I::RowRow(next_input)) => {
-                        differential_join_inner::<_, _, RowRowAgent<_, _>, RowRowEnter<_, _, _>>(
+                        differential_join_inner::<_, RowRowAgent<_, _>, RowRowEnter<_, _, _>>(
                             ctx, prev_keyed, next_input, None, None, None, closure,
                         )
                     }
@@ -423,7 +419,7 @@ where
             ArrangementFlavor::Local(oks, errs1) => {
                 let (oks, errs2) = match (trace, oks) {
                     (I::RowUnit(prev_keyed), A::RowUnit(next_input)) => {
-                        differential_join_inner::<_, _, RowEnter<_, _, _>, RowAgent<_, _>>(
+                        differential_join_inner::<_, RowEnter<_, _, _>, RowAgent<_, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -434,7 +430,7 @@ where
                         )
                     }
                     (I::RowUnit(prev_keyed), A::RowRow(next_input)) => {
-                        differential_join_inner::<_, _, RowEnter<_, _, _>, RowRowAgent<_, _>>(
+                        differential_join_inner::<_, RowEnter<_, _, _>, RowRowAgent<_, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -445,7 +441,7 @@ where
                         )
                     }
                     (I::RowRow(prev_keyed), A::RowUnit(next_input)) => {
-                        differential_join_inner::<_, _, RowRowEnter<_, _, _>, RowAgent<_, _>>(
+                        differential_join_inner::<_, RowRowEnter<_, _, _>, RowAgent<_, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -456,7 +452,7 @@ where
                         )
                     }
                     (I::RowRow(prev_keyed), A::RowRow(next_input)) => {
-                        differential_join_inner::<_, _, RowRowEnter<_, _, _>, RowRowAgent<_, _>>(
+                        differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowAgent<_, _>>(
                             ctx, prev_keyed, next_input, None, None, None, closure,
                         )
                     }
@@ -469,7 +465,7 @@ where
             ArrangementFlavor::Trace(_gid, oks, errs1) => {
                 let (oks, errs2) = match (trace, oks) {
                     (I::RowUnit(prev_keyed), I::RowUnit(next_input)) => {
-                        differential_join_inner::<_, _, RowEnter<_, _, _>, RowEnter<_, _, _>>(
+                        differential_join_inner::<_, RowEnter<_, _, _>, RowEnter<_, _, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -480,7 +476,7 @@ where
                         )
                     }
                     (I::RowUnit(prev_keyed), I::RowRow(next_input)) => {
-                        differential_join_inner::<_, _, RowEnter<_, _, _>, RowRowEnter<_, _, _>>(
+                        differential_join_inner::<_, RowEnter<_, _, _>, RowRowEnter<_, _, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -491,7 +487,7 @@ where
                         )
                     }
                     (I::RowRow(prev_keyed), I::RowUnit(next_input)) => {
-                        differential_join_inner::<_, _, RowRowEnter<_, _, _>, RowEnter<_, _, _>>(
+                        differential_join_inner::<_, RowRowEnter<_, _, _>, RowEnter<_, _, _>>(
                             ctx,
                             prev_keyed,
                             next_input,
@@ -502,7 +498,7 @@ where
                         )
                     }
                     (I::RowRow(prev_keyed), I::RowRow(next_input)) => {
-                        differential_join_inner::<_, _, RowRowEnter<_, _, _>, RowRowEnter<_, _, _>>(
+                        differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowEnter<_, _, _>>(
                             ctx, prev_keyed, next_input, None, None, None, closure,
                         )
                     }
@@ -522,21 +518,20 @@ where
 ///
 /// The return type includes an optional error collection, which may be
 /// `None` if we can determine that `closure` cannot error.
-fn differential_join_inner<C, S, Tr1, Tr2>(
+fn differential_join_inner<C, Tr1, Tr2>(
     ctx: &C,
-    prev_keyed: Arranged<S, Tr1>,
-    next_input: Arranged<S, Tr2>,
+    prev_keyed: Arranged<C::Scope, Tr1>,
+    next_input: Arranged<C::Scope, Tr2>,
     key_types: Option<Vec<ColumnType>>,
     prev_types: Option<Vec<ColumnType>>,
     next_types: Option<Vec<ColumnType>>,
     closure: JoinClosure,
 ) -> (
-    Collection<S, Row, Diff>,
-    Option<Collection<S, DataflowError, Diff>>,
+    Collection<C::Scope, Row, Diff>,
+    Option<Collection<C::Scope, DataflowError, Diff>>,
 )
 where
     C: Context,
-    S: Scope<Timestamp = C::Timestamp>,
     Tr1: TraceReader<Time = C::Timestamp, Diff = Diff> + Clone + 'static,
     Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = C::Timestamp, Diff = Diff>
         + Clone

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -141,89 +141,48 @@ where
     G::Timestamp: Lattice + Refines<T> + Columnation,
     T: Timestamp + Lattice + Columnation,
 {
-    pub(crate) fn render_join(
-        &mut self,
-        inputs: Vec<CollectionBundle<G, T>>,
-        linear_plan: LinearJoinPlan,
-    ) -> CollectionBundle<G, T> {
-        self.scope.clone().region_named("Join(Linear)", |inner| {
-            // Collect all error streams, and concatenate them at the end.
-            let mut errors = Vec::new();
+pub(crate) fn render_join(
+    &mut self,
+    inputs: Vec<CollectionBundle<G, T>>,
+    linear_plan: LinearJoinPlan,
+) -> CollectionBundle<G, T> {
+    self.scope.clone().region_named("Join(Linear)", |inner| {
+        // Collect all error streams, and concatenate them at the end.
+        let mut errors = Vec::new();
 
-            // Determine which form our maintained spine of updates will initially take.
-            // First, just check out the availability of an appropriate arrangement.
-            // This will be `None` in the degenerate single-input join case, which ensures
-            // that we do not panic if we never go around the `stage_plans` loop.
-            let arrangement = linear_plan.stage_plans.get(0).and_then(|stage| {
-                inputs[linear_plan.source_relation].arrangement(&stage.stream_key)
-            });
-            // We can use an arrangement if it exists and an initial closure does not.
-            let mut joined = match (arrangement, linear_plan.initial_closure) {
-                (Some(ArrangementFlavor::Local(oks, errs)), None) => {
-                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
-                    JoinedFlavor::Local(oks.enter_region(inner))
-                }
-                (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
-                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
-                    JoinedFlavor::Trace(oks.enter_region(inner))
-                }
-                (_, initial_closure) => {
-                    // TODO: extract closure from the first stage in the join plan, should it exist.
-                    // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
-                    let (joined, errs) = inputs[linear_plan.source_relation]
-                        .as_specific_collection(linear_plan.source_key.as_deref());
-                    errors.push(errs.enter_region(inner));
-                    let mut joined = joined.enter_region(inner);
-
-                    // In the current code this should always be `None`, but we have this here should
-                    // we change that and want to know what we should be doing.
-                    if let Some(closure) = initial_closure {
-                        // If there is no starting arrangement, then we can run filters
-                        // directly on the starting collection.
-                        // If there is only one input, we are done joining, so run filters
-                        let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
-                            // Reuseable allocation for unpacking.
-                            let mut datums = DatumVec::new();
-                            move |row| {
-                                let binding = SharedRow::get();
-                                let mut row_builder = binding.borrow_mut();
-                                let temp_storage = RowArena::new();
-                                let mut datums_local = datums.borrow_with(&row);
-                                // TODO(mcsherry): re-use `row` allocation.
-                                closure
-                                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                                    .map_err(DataflowError::from)
-                                    .transpose()
-                            }
-                        });
-                        joined = j;
-                        errors.push(errs);
-                    }
-
-                    JoinedFlavor::Collection(joined)
-                }
-            };
-
-            // progress through stages, updating partial results and errors.
-            for stage_plan in linear_plan.stage_plans.into_iter() {
-                // Different variants of `joined` implement this differently,
-                // and the logic is centralized there.
-                let stream = self.differential_join(
-                    joined,
-                    inputs[stage_plan.lookup_relation].enter_region(inner),
-                    stage_plan,
-                    &mut errors,
-                );
-                // Update joined results and capture any errors.
-                joined = JoinedFlavor::Collection(stream);
+        // Determine which form our maintained spine of updates will initially take.
+        // First, just check out the availability of an appropriate arrangement.
+        // This will be `None` in the degenerate single-input join case, which ensures
+        // that we do not panic if we never go around the `stage_plans` loop.
+        let arrangement = linear_plan
+            .stage_plans
+            .get(0)
+            .and_then(|stage| inputs[linear_plan.source_relation].arrangement(&stage.stream_key));
+        // We can use an arrangement if it exists and an initial closure does not.
+        let mut joined = match (arrangement, linear_plan.initial_closure) {
+            (Some(ArrangementFlavor::Local(oks, errs)), None) => {
+                errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                JoinedFlavor::Local(oks.enter_region(inner))
             }
+            (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
+                errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                JoinedFlavor::Trace(oks.enter_region(inner))
+            }
+            (_, initial_closure) => {
+                // TODO: extract closure from the first stage in the join plan, should it exist.
+                // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
+                let (joined, errs) = inputs[linear_plan.source_relation]
+                    .as_specific_collection(linear_plan.source_key.as_deref());
+                errors.push(errs.enter_region(inner));
+                let mut joined = joined.enter_region(inner);
 
-            // We have completed the join building, but may have work remaining.
-            // For example, we may have expressions not pushed down (e.g. literals)
-            // and projections that could not be applied (e.g. column repetition).
-            if let JoinedFlavor::Collection(mut joined) = joined {
-                if let Some(closure) = linear_plan.final_closure {
-                    let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
+                // In the current code this should always be `None`, but we have this here should
+                // we change that and want to know what we should be doing.
+                if let Some(closure) = initial_closure {
+                    // If there is no starting arrangement, then we can run filters
+                    // directly on the starting collection.
+                    // If there is only one input, we are done joining, so run filters
+                    let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
                         // Reuseable allocation for unpacking.
                         let mut datums = DatumVec::new();
                         move |row| {
@@ -238,319 +197,326 @@ where
                                 .transpose()
                         }
                     });
-
-                    joined = updates;
+                    joined = j;
                     errors.push(errs);
                 }
 
-                // Return joined results and all produced errors collected together.
-                CollectionBundle::from_collections(
-                    joined,
-                    differential_dataflow::collection::concatenate(inner, errors),
-                )
-            } else {
-                panic!("Unexpectedly arranged join output");
+                JoinedFlavor::Collection(joined)
             }
-            .leave_region()
-        })
-    }
+        };
 
-    /// Looks up the arrangement for the next input and joins it to the arranged
-    /// version of the join of previous inputs.
-    fn differential_join<S>(
-        &self,
-        mut joined: JoinedFlavor<S, T>,
-        lookup_relation: CollectionBundle<S, T>,
-        LinearStagePlan {
-            stream_key,
-            stream_thinning,
-            lookup_key,
-            closure,
-            lookup_relation: _,
-        }: LinearStagePlan,
-        errors: &mut Vec<Collection<S, DataflowError, Diff>>,
-    ) -> Collection<S, Row, Diff>
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        // If we have only a streamed collection, we must first form an arrangement.
-        if let JoinedFlavor::Collection(stream) = joined {
-            let (keyed, errs) = stream.map_fallible("LinearJoinKeyPreparation", {
-                // Reuseable allocation for unpacking.
-                let mut datums = DatumVec::new();
-                move |row| {
-                    let binding = SharedRow::get();
-                    let mut row_builder = binding.borrow_mut();
-                    let temp_storage = RowArena::new();
-                    let datums_local = datums.borrow_with(&row);
-                    row_builder.packer().try_extend(
-                        stream_key
-                            .iter()
-                            .map(|e| e.eval(&datums_local, &temp_storage)),
-                    )?;
-                    let key = row_builder.clone();
-                    row_builder
-                        .packer()
-                        .extend(stream_thinning.iter().map(|e| datums_local[*e]));
-                    let value = row_builder.clone();
-                    Ok((key, value))
-                }
-            });
-
-            errors.push(errs);
-
-            // TODO(vmarcos): We should implement further arrangement specialization here (#22104).
-            // By knowing how types propagate through joins we could specialize intermediate
-            // arrangements as well, either in values or eventually in keys.
-            let arranged = keyed.mz_arrange::<RowRowSpine<_, _>>("JoinStage");
-            joined = JoinedFlavor::Local(SpecializedArrangement::RowRow(arranged));
+        // progress through stages, updating partial results and errors.
+        for stage_plan in linear_plan.stage_plans.into_iter() {
+            // Different variants of `joined` implement this differently,
+            // and the logic is centralized there.
+            let stream = self.differential_join(
+                joined,
+                inputs[stage_plan.lookup_relation].enter_region(inner),
+                stage_plan,
+                &mut errors,
+            );
+            // Update joined results and capture any errors.
+            joined = JoinedFlavor::Collection(stream);
         }
 
-        // Demultiplex the four different cross products of arrangement types we might have.
-        let arrangement = lookup_relation
-            .arrangement(&lookup_key[..])
-            .expect("Arrangement absent despite explicit construction");
-
-        use SpecializedArrangement as A;
-        use SpecializedArrangementImport as I;
-
-        match joined {
-            JoinedFlavor::Collection(_) => {
-                unreachable!("JoinedFlavor::Collection variant avoided at top of method");
-            }
-            JoinedFlavor::Local(local) => match arrangement {
-                ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) = match (local, oks) {
-                        (A::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowAgent<_, _>, RowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                Some(vec![]),
-                                closure,
-                            ),
-                        (A::RowUnit(prev_keyed), A::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowAgent<_, _>, RowRowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                None,
-                                closure,
-                            ),
-                        (A::RowRow(prev_keyed), A::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowRowAgent<_, _>, RowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                None,
-                                Some(vec![]),
-                                closure,
-                            ),
-                        (A::RowRow(prev_keyed), A::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowRowAgent<_, _>, RowRowAgent<_, _>>(
-                                prev_keyed, next_input, None, None, None, closure,
-                            ),
-                    };
-
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-                ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = match (local, oks) {
-                        (A::RowUnit(prev_keyed), I::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowAgent<_, _>, RowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                Some(vec![]),
-                                closure,
-                            ),
-                        (A::RowUnit(prev_keyed), I::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowAgent<_, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                None,
-                                closure,
-                            ),
-                        (A::RowRow(prev_keyed), I::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowRowAgent<_, _>, RowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                None,
-                                Some(vec![]),
-                                closure,
-                            ),
-                        (A::RowRow(prev_keyed), I::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowRowAgent<_, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed, next_input, None, None, None, closure,
-                            ),
-                    };
-
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-            },
-            JoinedFlavor::Trace(trace) => match arrangement {
-                ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) = match (trace, oks) {
-                        (I::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowEnter<_, _, _>, RowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                Some(vec![]),
-                                closure,
-                            ),
-                        (I::RowUnit(prev_keyed), A::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowEnter<_, _, _>, RowRowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                None,
-                                closure,
-                            ),
-                        (I::RowRow(prev_keyed), A::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowRowEnter<_, _, _>, RowAgent<_, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                None,
-                                Some(vec![]),
-                                closure,
-                            ),
-                        (I::RowRow(prev_keyed), A::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowAgent<_, _>>(
-                                prev_keyed, next_input, None, None, None, closure,
-                            ),
-                    };
-
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-                ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = match (trace, oks) {
-                        (I::RowUnit(prev_keyed), I::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowEnter<_, _, _>, RowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                Some(vec![]),
-                                closure,
-                            ),
-                        (I::RowUnit(prev_keyed), I::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowEnter<_, _, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                Some(vec![]),
-                                None,
-                                closure,
-                            ),
-                        (I::RowRow(prev_keyed), I::RowUnit(next_input)) => self
-                            .differential_join_inner::<_, RowRowEnter<_, _, _>, RowEnter<_, _, _>>(
-                                prev_keyed,
-                                next_input,
-                                None,
-                                None,
-                                Some(vec![]),
-                                closure,
-                            ),
-                        (I::RowRow(prev_keyed), I::RowRow(next_input)) => self
-                            .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowEnter<_, _, _>>(
-                                prev_keyed, next_input, None, None, None, closure,
-                            ),
-                    };
-
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-            },
-        }
-    }
-
-    /// Joins the arrangement for `next_input` to the arranged version of the
-    /// join of previous inputs. This is split into its own method to enable
-    /// reuse of code with different types of `next_input`.
-    ///
-    /// The return type includes an optional error collection, which may be
-    /// `None` if we can determine that `closure` cannot error.
-    fn differential_join_inner<S, Tr1, Tr2>(
-        &self,
-        prev_keyed: Arranged<S, Tr1>,
-        next_input: Arranged<S, Tr2>,
-        key_types: Option<Vec<ColumnType>>,
-        prev_types: Option<Vec<ColumnType>>,
-        next_types: Option<Vec<ColumnType>>,
-        closure: JoinClosure,
-    ) -> (
-        Collection<S, Row, Diff>,
-        Option<Collection<S, DataflowError, Diff>>,
-    )
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-        Tr1: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-        Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = G::Timestamp, Diff = Diff>
-            + Clone
-            + 'static,
-        for<'a> Tr1::Key<'a>: IntoRowByTypes,
-        for<'a> Tr1::Val<'a>: IntoRowByTypes,
-        for<'a> Tr2::Val<'a>: IntoRowByTypes,
-    {
-        // Reuseable allocation for unpacking.
-        let mut datums = DatumVec::new();
-
-        if closure.could_error() {
-            let (oks, err) = self
-                .linear_join_spec
-                .render(
-                    &prev_keyed,
-                    &next_input,
-                    self.shutdown_token.clone(),
-                    move |key, old, new| {
+        // We have completed the join building, but may have work remaining.
+        // For example, we may have expressions not pushed down (e.g. literals)
+        // and projections that could not be applied (e.g. column repetition).
+        if let JoinedFlavor::Collection(mut joined) = joined {
+            if let Some(closure) = linear_plan.final_closure {
+                let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
+                    // Reuseable allocation for unpacking.
+                    let mut datums = DatumVec::new();
+                    move |row| {
                         let binding = SharedRow::get();
                         let mut row_builder = binding.borrow_mut();
                         let temp_storage = RowArena::new();
-
-                        let key = key.into_datum_iter(key_types.as_deref());
-                        let old = old.into_datum_iter(prev_types.as_deref());
-                        let new = new.into_datum_iter(next_types.as_deref());
-
-                        let mut datums_local = datums.borrow();
-                        datums_local.extend(key);
-                        datums_local.extend(old);
-                        datums_local.extend(new);
-
+                        let mut datums_local = datums.borrow_with(&row);
+                        // TODO(mcsherry): re-use `row` allocation.
                         closure
                             .apply(&mut datums_local, &temp_storage, &mut row_builder)
                             .map_err(DataflowError::from)
                             .transpose()
-                    },
-                )
-                .inner
-                .ok_err(|(x, t, d)| {
-                    // TODO(mcsherry): consider `ok_err()` for `Collection`.
-                    match x {
-                        Ok(x) => Ok((x, t, d)),
-                        Err(x) => Err((x, t, d)),
                     }
                 });
 
-            (oks.as_collection(), Some(err.as_collection()))
+                joined = updates;
+                errors.push(errs);
+            }
+
+            // Return joined results and all produced errors collected together.
+            CollectionBundle::from_collections(
+                joined,
+                differential_dataflow::collection::concatenate(inner, errors),
+            )
         } else {
-            let oks = self.linear_join_spec.render(
+            panic!("Unexpectedly arranged join output");
+        }
+        .leave_region()
+    })
+}
+
+/// Looks up the arrangement for the next input and joins it to the arranged
+/// version of the join of previous inputs.
+fn differential_join<S>(
+    &self,
+    mut joined: JoinedFlavor<S, T>,
+    lookup_relation: CollectionBundle<S, T>,
+    LinearStagePlan {
+        stream_key,
+        stream_thinning,
+        lookup_key,
+        closure,
+        lookup_relation: _,
+    }: LinearStagePlan,
+    errors: &mut Vec<Collection<S, DataflowError, Diff>>,
+) -> Collection<S, Row, Diff>
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    // If we have only a streamed collection, we must first form an arrangement.
+    if let JoinedFlavor::Collection(stream) = joined {
+        let (keyed, errs) = stream.map_fallible("LinearJoinKeyPreparation", {
+            // Reuseable allocation for unpacking.
+            let mut datums = DatumVec::new();
+            move |row| {
+                let binding = SharedRow::get();
+                let mut row_builder = binding.borrow_mut();
+                let temp_storage = RowArena::new();
+                let datums_local = datums.borrow_with(&row);
+                row_builder.packer().try_extend(
+                    stream_key
+                        .iter()
+                        .map(|e| e.eval(&datums_local, &temp_storage)),
+                )?;
+                let key = row_builder.clone();
+                row_builder
+                    .packer()
+                    .extend(stream_thinning.iter().map(|e| datums_local[*e]));
+                let value = row_builder.clone();
+                Ok((key, value))
+            }
+        });
+
+        errors.push(errs);
+
+        // TODO(vmarcos): We should implement further arrangement specialization here (#22104).
+        // By knowing how types propagate through joins we could specialize intermediate
+        // arrangements as well, either in values or eventually in keys.
+        let arranged = keyed.mz_arrange::<RowRowSpine<_, _>>("JoinStage");
+        joined = JoinedFlavor::Local(SpecializedArrangement::RowRow(arranged));
+    }
+
+    // Demultiplex the four different cross products of arrangement types we might have.
+    let arrangement = lookup_relation
+        .arrangement(&lookup_key[..])
+        .expect("Arrangement absent despite explicit construction");
+
+    use SpecializedArrangement as A;
+    use SpecializedArrangementImport as I;
+
+    match joined {
+        JoinedFlavor::Collection(_) => {
+            unreachable!("JoinedFlavor::Collection variant avoided at top of method");
+        }
+        JoinedFlavor::Local(local) => match arrangement {
+            ArrangementFlavor::Local(oks, errs1) => {
+                let (oks, errs2) = match (local, oks) {
+                    (A::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
+                        .differential_join_inner::<_, RowAgent<_, _>, RowAgent<_, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            Some(vec![]),
+                            closure,
+                        ),
+                    (A::RowUnit(prev_keyed), A::RowRow(next_input)) => self
+                        .differential_join_inner::<_, RowAgent<_, _>, RowRowAgent<_, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            None,
+                            closure,
+                        ),
+                    (A::RowRow(prev_keyed), A::RowUnit(next_input)) => self
+                        .differential_join_inner::<_, RowRowAgent<_, _>, RowAgent<_, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            None,
+                            Some(vec![]),
+                            closure,
+                        ),
+                    (A::RowRow(prev_keyed), A::RowRow(next_input)) => self
+                        .differential_join_inner::<_, RowRowAgent<_, _>, RowRowAgent<_, _>>(
+                            prev_keyed, next_input, None, None, None, closure,
+                        ),
+                };
+
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+            ArrangementFlavor::Trace(_gid, oks, errs1) => {
+                let (oks, errs2) = match (local, oks) {
+                    (A::RowUnit(prev_keyed), I::RowUnit(next_input)) => self
+                        .differential_join_inner::<_, RowAgent<_, _>, RowEnter<_, _, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            Some(vec![]),
+                            closure,
+                        ),
+                    (A::RowUnit(prev_keyed), I::RowRow(next_input)) => self
+                        .differential_join_inner::<_, RowAgent<_, _>, RowRowEnter<_, _, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            None,
+                            closure,
+                        ),
+                    (A::RowRow(prev_keyed), I::RowUnit(next_input)) => self
+                        .differential_join_inner::<_, RowRowAgent<_, _>, RowEnter<_, _, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            None,
+                            Some(vec![]),
+                            closure,
+                        ),
+                    (A::RowRow(prev_keyed), I::RowRow(next_input)) => self
+                        .differential_join_inner::<_, RowRowAgent<_, _>, RowRowEnter<_, _, _>>(
+                            prev_keyed, next_input, None, None, None, closure,
+                        ),
+                };
+
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+        },
+        JoinedFlavor::Trace(trace) => match arrangement {
+            ArrangementFlavor::Local(oks, errs1) => {
+                let (oks, errs2) = match (trace, oks) {
+                    (I::RowUnit(prev_keyed), A::RowUnit(next_input)) => self
+                        .differential_join_inner::<_, RowEnter<_, _, _>, RowAgent<_, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            Some(vec![]),
+                            closure,
+                        ),
+                    (I::RowUnit(prev_keyed), A::RowRow(next_input)) => self
+                        .differential_join_inner::<_, RowEnter<_, _, _>, RowRowAgent<_, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            None,
+                            closure,
+                        ),
+                    (I::RowRow(prev_keyed), A::RowUnit(next_input)) => self
+                        .differential_join_inner::<_, RowRowEnter<_, _, _>, RowAgent<_, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            None,
+                            Some(vec![]),
+                            closure,
+                        ),
+                    (I::RowRow(prev_keyed), A::RowRow(next_input)) => self
+                        .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowAgent<_, _>>(
+                            prev_keyed, next_input, None, None, None, closure,
+                        ),
+                };
+
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+            ArrangementFlavor::Trace(_gid, oks, errs1) => {
+                let (oks, errs2) = match (trace, oks) {
+                    (I::RowUnit(prev_keyed), I::RowUnit(next_input)) => self
+                        .differential_join_inner::<_, RowEnter<_, _, _>, RowEnter<_, _, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            Some(vec![]),
+                            closure,
+                        ),
+                    (I::RowUnit(prev_keyed), I::RowRow(next_input)) => self
+                        .differential_join_inner::<_, RowEnter<_, _, _>, RowRowEnter<_, _, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            Some(vec![]),
+                            None,
+                            closure,
+                        ),
+                    (I::RowRow(prev_keyed), I::RowUnit(next_input)) => self
+                        .differential_join_inner::<_, RowRowEnter<_, _, _>, RowEnter<_, _, _>>(
+                            prev_keyed,
+                            next_input,
+                            None,
+                            None,
+                            Some(vec![]),
+                            closure,
+                        ),
+                    (I::RowRow(prev_keyed), I::RowRow(next_input)) => self
+                        .differential_join_inner::<_, RowRowEnter<_, _, _>, RowRowEnter<_, _, _>>(
+                            prev_keyed, next_input, None, None, None, closure,
+                        ),
+                };
+
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+        },
+    }
+}
+
+/// Joins the arrangement for `next_input` to the arranged version of the
+/// join of previous inputs. This is split into its own method to enable
+/// reuse of code with different types of `next_input`.
+///
+/// The return type includes an optional error collection, which may be
+/// `None` if we can determine that `closure` cannot error.
+fn differential_join_inner<S, Tr1, Tr2>(
+    &self,
+    prev_keyed: Arranged<S, Tr1>,
+    next_input: Arranged<S, Tr2>,
+    key_types: Option<Vec<ColumnType>>,
+    prev_types: Option<Vec<ColumnType>>,
+    next_types: Option<Vec<ColumnType>>,
+    closure: JoinClosure,
+) -> (
+    Collection<S, Row, Diff>,
+    Option<Collection<S, DataflowError, Diff>>,
+)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+    Tr1: TraceReader<Time = G::Timestamp, Diff = Diff> + Clone + 'static,
+    Tr2: for<'a> TraceReader<Key<'a> = Tr1::Key<'a>, Time = G::Timestamp, Diff = Diff>
+        + Clone
+        + 'static,
+    for<'a> Tr1::Key<'a>: IntoRowByTypes,
+    for<'a> Tr1::Val<'a>: IntoRowByTypes,
+    for<'a> Tr2::Val<'a>: IntoRowByTypes,
+{
+    // Reuseable allocation for unpacking.
+    let mut datums = DatumVec::new();
+
+    if closure.could_error() {
+        let (oks, err) = self
+            .linear_join_spec
+            .render(
                 &prev_keyed,
                 &next_input,
                 self.shutdown_token.clone(),
@@ -570,11 +536,46 @@ where
 
                     closure
                         .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                        .expect("Closure claimed to never error")
+                        .map_err(DataflowError::from)
+                        .transpose()
                 },
-            );
+            )
+            .inner
+            .ok_err(|(x, t, d)| {
+                // TODO(mcsherry): consider `ok_err()` for `Collection`.
+                match x {
+                    Ok(x) => Ok((x, t, d)),
+                    Err(x) => Err((x, t, d)),
+                }
+            });
 
-            (oks, None)
-        }
+        (oks.as_collection(), Some(err.as_collection()))
+    } else {
+        let oks = self.linear_join_spec.render(
+            &prev_keyed,
+            &next_input,
+            self.shutdown_token.clone(),
+            move |key, old, new| {
+                let binding = SharedRow::get();
+                let mut row_builder = binding.borrow_mut();
+                let temp_storage = RowArena::new();
+
+                let key = key.into_datum_iter(key_types.as_deref());
+                let old = old.into_datum_iter(prev_types.as_deref());
+                let new = new.into_datum_iter(next_types.as_deref());
+
+                let mut datums_local = datums.borrow();
+                datums_local.extend(key);
+                datums_local.extend(old);
+                datums_local.extend(new);
+
+                closure
+                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                    .expect("Closure claimed to never error")
+            },
+        );
+
+        (oks, None)
     }
+}
 }

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -27,6 +27,7 @@ use mz_timely_util::operator::CollectionExt;
 use timely::container::columnation::Columnation;
 use timely::dataflow::operators::OkErr;
 use timely::dataflow::Scope;
+use timely::dataflow::scopes::Child;
 use timely::progress::timestamp::{Refines, Timestamp};
 
 use crate::extensions::arrange::MzArrange;
@@ -141,85 +142,52 @@ pub(crate) fn render_join<C: Context>(
     linear_plan: LinearJoinPlan,
 ) -> CollectionBundle<C::Scope> {
     ctx.scope().clone().region_named("Join(Linear)", |inner| {
-        // Collect all error streams, and concatenate them at the end.
-        let mut errors = Vec::new();
+        render_join_inner(ctx, inputs, linear_plan, inner)
+    })
+}
 
-        // Determine which form our maintained spine of updates will initially take.
-        // First, just check out the availability of an appropriate arrangement.
-        // This will be `None` in the degenerate single-input join case, which ensures
-        // that we do not panic if we never go around the `stage_plans` loop.
-        let arrangement = linear_plan
-            .stage_plans
-            .get(0)
-            .and_then(|stage| inputs[linear_plan.source_relation].arrangement(&stage.stream_key));
-        // We can use an arrangement if it exists and an initial closure does not.
-        let mut joined = match (arrangement, linear_plan.initial_closure) {
-            (Some(ArrangementFlavor::Local(oks, errs)), None) => {
-                errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
-                JoinedFlavor::Local(oks.enter_region(inner))
-            }
-            (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
-                errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
-                JoinedFlavor::Trace(oks.enter_region(inner))
-            }
-            (_, initial_closure) => {
-                // TODO: extract closure from the first stage in the join plan, should it exist.
-                // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
-                let (joined, errs) = inputs[linear_plan.source_relation]
-                    .as_specific_collection(linear_plan.source_key.as_deref());
-                errors.push(errs.enter_region(inner));
-                let mut joined = joined.enter_region(inner);
+fn render_join_inner<C: Context>(
+    ctx: &C,
+    inputs: Vec<CollectionBundle<C::Scope>>,
+    linear_plan: LinearJoinPlan,
+    inner: &mut Child<C::Scope, C::Timestamp>,
+) -> CollectionBundle<C::Scope> {
+    // Collect all error streams, and concatenate them at the end.
+    let mut errors = Vec::new();
 
-                // In the current code this should always be `None`, but we have this here should
-                // we change that and want to know what we should be doing.
-                if let Some(closure) = initial_closure {
-                    // If there is no starting arrangement, then we can run filters
-                    // directly on the starting collection.
-                    // If there is only one input, we are done joining, so run filters
-                    let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
-                        // Reuseable allocation for unpacking.
-                        let mut datums = DatumVec::new();
-                        move |row| {
-                            let binding = SharedRow::get();
-                            let mut row_builder = binding.borrow_mut();
-                            let temp_storage = RowArena::new();
-                            let mut datums_local = datums.borrow_with(&row);
-                            // TODO(mcsherry): re-use `row` allocation.
-                            closure
-                                .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                                .map_err(DataflowError::from)
-                                .transpose()
-                        }
-                    });
-                    joined = j;
-                    errors.push(errs);
-                }
-
-                JoinedFlavor::Collection(joined)
-            }
-        };
-
-        // progress through stages, updating partial results and errors.
-        for stage_plan in linear_plan.stage_plans.into_iter() {
-            // Different variants of `joined` implement this differently,
-            // and the logic is centralized there.
-            let stream = differential_join(
-                ctx,
-                joined,
-                inputs[stage_plan.lookup_relation].enter_region(inner),
-                stage_plan,
-                &mut errors,
-            );
-            // Update joined results and capture any errors.
-            joined = JoinedFlavor::Collection(stream);
+    // Determine which form our maintained spine of updates will initially take.
+    // First, just check out the availability of an appropriate arrangement.
+    // This will be `None` in the degenerate single-input join case, which ensures
+    // that we do not panic if we never go around the `stage_plans` loop.
+    let arrangement = linear_plan
+        .stage_plans
+        .get(0)
+        .and_then(|stage| inputs[linear_plan.source_relation].arrangement(&stage.stream_key));
+    // We can use an arrangement if it exists and an initial closure does not.
+    let mut joined = match (arrangement, linear_plan.initial_closure) {
+        (Some(ArrangementFlavor::Local(oks, errs)), None) => {
+            errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+            JoinedFlavor::Local(oks.enter_region(inner))
         }
+        (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
+            errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+            JoinedFlavor::Trace(oks.enter_region(inner))
+        }
+        (_, initial_closure) => {
+            // TODO: extract closure from the first stage in the join plan, should it exist.
+            // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
+            let (joined, errs) = inputs[linear_plan.source_relation]
+                .as_specific_collection(linear_plan.source_key.as_deref());
+            errors.push(errs.enter_region(inner));
+            let mut joined = joined.enter_region(inner);
 
-        // We have completed the join building, but may have work remaining.
-        // For example, we may have expressions not pushed down (e.g. literals)
-        // and projections that could not be applied (e.g. column repetition).
-        if let JoinedFlavor::Collection(mut joined) = joined {
-            if let Some(closure) = linear_plan.final_closure {
-                let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
+            // In the current code this should always be `None`, but we have this here should
+            // we change that and want to know what we should be doing.
+            if let Some(closure) = initial_closure {
+                // If there is no starting arrangement, then we can run filters
+                // directly on the starting collection.
+                // If there is only one input, we are done joining, so run filters
+                let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
                     // Reuseable allocation for unpacking.
                     let mut datums = DatumVec::new();
                     move |row| {
@@ -234,21 +202,63 @@ pub(crate) fn render_join<C: Context>(
                             .transpose()
                     }
                 });
-
-                joined = updates;
+                joined = j;
                 errors.push(errs);
             }
 
-            // Return joined results and all produced errors collected together.
-            CollectionBundle::from_collections(
-                joined,
-                differential_dataflow::collection::concatenate(inner, errors),
-            )
-        } else {
-            panic!("Unexpectedly arranged join output");
+            JoinedFlavor::Collection(joined)
         }
-        .leave_region()
-    })
+    };
+
+    // progress through stages, updating partial results and errors.
+    for stage_plan in linear_plan.stage_plans.into_iter() {
+        // Different variants of `joined` implement this differently,
+        // and the logic is centralized there.
+        let stream = differential_join(
+            ctx,
+            joined,
+            inputs[stage_plan.lookup_relation].enter_region(inner),
+            stage_plan,
+            &mut errors,
+        );
+        // Update joined results and capture any errors.
+        joined = JoinedFlavor::Collection(stream);
+    }
+
+    // We have completed the join building, but may have work remaining.
+    // For example, we may have expressions not pushed down (e.g. literals)
+    // and projections that could not be applied (e.g. column repetition).
+    if let JoinedFlavor::Collection(mut joined) = joined {
+        if let Some(closure) = linear_plan.final_closure {
+            let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
+                // Reuseable allocation for unpacking.
+                let mut datums = DatumVec::new();
+                move |row| {
+                    let binding = SharedRow::get();
+                    let mut row_builder = binding.borrow_mut();
+                    let temp_storage = RowArena::new();
+                    let mut datums_local = datums.borrow_with(&row);
+                    // TODO(mcsherry): re-use `row` allocation.
+                    closure
+                        .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                        .map_err(DataflowError::from)
+                        .transpose()
+                }
+            });
+
+            joined = updates;
+            errors.push(errs);
+        }
+
+        // Return joined results and all produced errors collected together.
+        CollectionBundle::from_collections(
+            joined,
+            differential_dataflow::collection::concatenate(inner, errors),
+        )
+    } else {
+        panic!("Unexpectedly arranged join output");
+    }
+    .leave_region()
 }
 
 /// Looks up the arrangement for the next input and joins it to the arranged

--- a/src/compute/src/render/join/mod.rs
+++ b/src/compute/src/render/join/mod.rs
@@ -15,4 +15,6 @@ mod delta_join;
 mod linear_join;
 mod mz_join_core;
 
+pub(super) use delta_join::render_delta_join;
+pub(super) use linear_join::render_join;
 pub use linear_join::{LinearJoinImpl, LinearJoinSpec};

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -378,7 +378,7 @@ pub fn build_compute_dataflow<A: Allocate>(
     })
 }
 
-pub(crate) fn import_index<'g, C, G, T>(
+fn import_index<'g, C, G, T>(
     ctx: &mut C,
     compute_state: &mut ComputeState,
     tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
@@ -441,13 +441,13 @@ pub(crate) fn import_index<'g, C, G, T>(
     }
 }
 
-pub(crate) fn build_object<C: Context>(ctx: &mut C, object: BuildDesc<Plan>) {
+fn build_object<C: Context>(ctx: &mut C, object: BuildDesc<Plan>) {
     // First, transform the relation expression into a render plan.
     let bundle = render_plan(ctx, object.plan);
     ctx.insert_id(Id::Global(object.id), bundle);
 }
 
-pub(crate) fn export_index<'g, C, G>(
+fn export_index<'g, C, G>(
     ctx: &C,
     compute_state: &mut ComputeState,
     tokens: &BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
@@ -508,7 +508,7 @@ pub(crate) fn export_index<'g, C, G>(
     };
 }
 
-pub(crate) fn export_index_iterative<'g, C, G, T>(
+fn export_index_iterative<'g, C, G, T>(
     ctx: &C,
     compute_state: &mut ComputeState,
     tokens: &BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
@@ -633,7 +633,7 @@ where
 ///
 /// The method requires that all variables conclude with a physical representation that
 /// contains a collection (i.e. a non-arrangement), and it will panic otherwise.
-pub fn render_recursive_plan<C: Context>(
+fn render_recursive_plan<C: Context>(
     ctx: &mut C,
     level: usize,
     plan: Plan,
@@ -750,7 +750,7 @@ where
 ///
 /// The return type reflects the uncertainty about the data representation, perhaps
 /// as a stream of data, perhaps as an arrangement, perhaps as a stream of batches.
-pub fn render_plan<C: Context>(ctx: &mut C, plan: Plan) -> CollectionBundle<C::Scope> {
+fn render_plan<C: Context>(ctx: &mut C, plan: Plan) -> CollectionBundle<C::Scope> {
     match plan {
         Plan::Constant { rows } => {
             // Produce both rows and errs to avoid conditional dataflow construction.

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -58,380 +58,300 @@ where
     G::Timestamp: Lattice + Refines<T> + Columnation,
     T: Timestamp + Lattice + Columnation,
 {
-    /// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
-    /// minimize worst-case incremental update times and memory footprint.
-    pub fn render_reduce(
-        &mut self,
-        input: CollectionBundle<G, T>,
-        key_val_plan: KeyValPlan,
-        reduce_plan: ReducePlan,
-        input_key: Option<Vec<MirScalarExpr>>,
-        mfp_after: Option<MapFilterProject>,
-    ) -> CollectionBundle<G, T> {
-        // Convert `mfp_after` to an actionable plan.
-        let mfp_after = mfp_after.map(|m| {
-            m.into_plan()
-                .expect("MFP planning must succeed")
-                .into_nontemporal()
-                .expect("Fused Reduce MFPs do not have temporal predicates")
-        });
+/// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
+/// minimize worst-case incremental update times and memory footprint.
+pub fn render_reduce(
+    &mut self,
+    input: CollectionBundle<G, T>,
+    key_val_plan: KeyValPlan,
+    reduce_plan: ReducePlan,
+    input_key: Option<Vec<MirScalarExpr>>,
+    mfp_after: Option<MapFilterProject>,
+) -> CollectionBundle<G, T> {
+    // Convert `mfp_after` to an actionable plan.
+    let mfp_after = mfp_after.map(|m| {
+        m.into_plan()
+            .expect("MFP planning must succeed")
+            .into_nontemporal()
+            .expect("Fused Reduce MFPs do not have temporal predicates")
+    });
 
-        input.scope().region_named("Reduce", |inner| {
-            let KeyValPlan {
-                mut key_plan,
-                mut val_plan,
-            } = key_val_plan;
-            let key_arity = key_plan.projection.len();
-            let mut datums = DatumVec::new();
-            let (key_val_input, err_input): (
-                timely::dataflow::Stream<_, (Result<(Row, Row), DataflowError>, _, _)>,
-                _,
-            ) = input
-                .enter_region(inner)
-                .flat_map(input_key.map(|k| (k, None)), || {
-                    // Determine the columns we'll need from the row.
-                    let mut demand = Vec::new();
-                    demand.extend(key_plan.demand());
-                    demand.extend(val_plan.demand());
-                    demand.sort();
-                    demand.dedup();
-                    // remap column references to the subset we use.
-                    let mut demand_map = BTreeMap::new();
-                    for column in demand.iter() {
-                        demand_map.insert(*column, demand_map.len());
-                    }
-                    let demand_map_len = demand_map.len();
-                    key_plan.permute(demand_map.clone(), demand_map_len);
-                    val_plan.permute(demand_map, demand_map_len);
-                    let skips = mz_compute_types::plan::reduce::convert_indexes_to_skips(demand);
-                    move |row_datums, time, diff| {
-                        let binding = SharedRow::get();
-                        let mut row_builder = binding.borrow_mut();
-                        let temp_storage = RowArena::new();
-
-                        let mut row_iter = row_datums.drain(..);
-                        let mut datums_local = datums.borrow();
-                        // Unpack only the demanded columns.
-                        for skip in skips.iter() {
-                            datums_local.push(row_iter.nth(*skip).unwrap());
-                        }
-
-                        // Evaluate the key expressions.
-                        let key = match key_plan.evaluate_into(
-                            &mut datums_local,
-                            &temp_storage,
-                            &mut row_builder,
-                        ) {
-                            Err(e) => {
-                                return Some((
-                                    Err(DataflowError::from(e)),
-                                    time.clone(),
-                                    diff.clone(),
-                                ))
-                            }
-                            Ok(key) => key.expect("Row expected as no predicate was used"),
-                        };
-                        // Evaluate the value expressions.
-                        // The prior evaluation may have left additional columns we should delete.
-                        datums_local.truncate(skips.len());
-                        let val = match val_plan.evaluate_iter(&mut datums_local, &temp_storage) {
-                            Err(e) => {
-                                return Some((
-                                    Err(DataflowError::from(e)),
-                                    time.clone(),
-                                    diff.clone(),
-                                ))
-                            }
-                            Ok(val) => val.expect("Row expected as no predicate was used"),
-                        };
-                        row_builder.packer().extend(val);
-                        let row = row_builder.clone();
-                        Some((Ok((key, row)), time.clone(), diff.clone()))
-                    }
-                });
-
-            // Demux out the potential errors from key and value selector evaluation.
-            let (ok, mut err) = key_val_input
-                .as_collection()
-                .consolidate_stream()
-                .flat_map_fallible("OkErrDemux", Some);
-
-            err = err.concat(&err_input);
-
-            // Render the reduce plan
-            self.render_reduce_plan(reduce_plan, ok, err, key_arity, mfp_after)
-                .leave_region()
-        })
-    }
-
-    /// Render a dataflow based on the provided plan.
-    ///
-    /// The output will be an arrangements that looks the same as if
-    /// we just had a single reduce operator computing everything together, and
-    /// this arrangement can also be re-used.
-    fn render_reduce_plan<S>(
-        &self,
-        plan: ReducePlan,
-        collection: Collection<S, (Row, Row), Diff>,
-        err_input: Collection<S, DataflowError, Diff>,
-        key_arity: usize,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> CollectionBundle<S, T>
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        let mut errors = Default::default();
-        let arrangement =
-            self.render_reduce_plan_inner(plan, collection, &mut errors, key_arity, mfp_after);
-        let errs: KeyCollection<_, _, _> = err_input.concatenate(errors).into();
-        CollectionBundle::from_columns(
-            0..key_arity,
-            ArrangementFlavor::Local(arrangement, errs.mz_arrange("Arrange bundle err")),
-        )
-    }
-
-    fn render_reduce_plan_inner<S>(
-        &self,
-        plan: ReducePlan,
-        collection: Collection<S, (Row, Row), Diff>,
-        errors: &mut Vec<Collection<S, DataflowError, Diff>>,
-        key_arity: usize,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> SpecializedArrangement<S>
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        // TODO(vmarcos): Arrangement specialization here could eventually be extended to keys,
-        // not only values (#22103).
-        let arrangement = match plan {
-            // If we have no aggregations or just a single type of reduction, we
-            // can go ahead and render them directly.
-            ReducePlan::Distinct => {
-                let (arranged_output, errs) = self.dispatch_build_distinct(collection, mfp_after);
-                errors.push(errs);
-                arranged_output
-            }
-            ReducePlan::Accumulable(expr) => {
-                let (arranged_output, errs) = self.build_accumulable(collection, expr, mfp_after);
-                errors.push(errs);
-                SpecializedArrangement::RowRow(arranged_output)
-            }
-            ReducePlan::Hierarchical(HierarchicalPlan::Monotonic(expr)) => {
-                let (output, errs) = self.build_monotonic(collection, expr, mfp_after);
-                errors.push(errs);
-                SpecializedArrangement::RowRow(output)
-            }
-            ReducePlan::Hierarchical(HierarchicalPlan::Bucketed(expr)) => {
-                let (output, errs) = self.build_bucketed(collection, expr, mfp_after);
-                errors.push(errs);
-                SpecializedArrangement::RowRow(output)
-            }
-            ReducePlan::Basic(BasicPlan::Single(index, aggr)) => {
-                let (output, errs) =
-                    self.build_basic_aggregate(collection, index, &aggr, true, mfp_after);
-                errors.push(errs.expect("validation should have occurred as it was requested"));
-                SpecializedArrangement::RowRow(output)
-            }
-            ReducePlan::Basic(BasicPlan::Multiple(aggrs)) => {
-                let (output, errs) = self.build_basic_aggregates(collection, aggrs, mfp_after);
-                errors.push(errs);
-                SpecializedArrangement::RowRow(output)
-            }
-            // Otherwise, we need to render something different for each type of
-            // reduction, and then stitch them together.
-            ReducePlan::Collation(expr) => {
-                // First, we need to render our constituent aggregations.
-                let mut to_collate = vec![];
-
-                for plan in [
-                    expr.hierarchical.map(ReducePlan::Hierarchical),
-                    expr.accumulable.map(ReducePlan::Accumulable),
-                    expr.basic.map(ReducePlan::Basic),
-                ]
-                .into_iter()
-                .flat_map(std::convert::identity)
-                {
-                    let r#type = ReductionType::try_from(&plan)
-                        .expect("only representable reduction types were used above");
-
-                    let arrangement = match self.render_reduce_plan_inner(
-                        plan,
-                        collection.clone(),
-                        errors,
-                        key_arity,
-                        None,
-                    ) {
-                        SpecializedArrangement::RowUnit(_) => {
-                            unreachable!(
-                                "Unexpected RowUnit arrangement in reduce collation rendering"
-                            )
-                        }
-                        SpecializedArrangement::RowRow(arranged) => arranged,
-                    };
-                    to_collate.push((r#type, arrangement));
+    input.scope().region_named("Reduce", |inner| {
+        let KeyValPlan {
+            mut key_plan,
+            mut val_plan,
+        } = key_val_plan;
+        let key_arity = key_plan.projection.len();
+        let mut datums = DatumVec::new();
+        let (key_val_input, err_input): (
+            timely::dataflow::Stream<_, (Result<(Row, Row), DataflowError>, _, _)>,
+            _,
+        ) = input
+            .enter_region(inner)
+            .flat_map(input_key.map(|k| (k, None)), || {
+                // Determine the columns we'll need from the row.
+                let mut demand = Vec::new();
+                demand.extend(key_plan.demand());
+                demand.extend(val_plan.demand());
+                demand.sort();
+                demand.dedup();
+                // remap column references to the subset we use.
+                let mut demand_map = BTreeMap::new();
+                for column in demand.iter() {
+                    demand_map.insert(*column, demand_map.len());
                 }
+                let demand_map_len = demand_map.len();
+                key_plan.permute(demand_map.clone(), demand_map_len);
+                val_plan.permute(demand_map, demand_map_len);
+                let skips = mz_compute_types::plan::reduce::convert_indexes_to_skips(demand);
+                move |row_datums, time, diff| {
+                    let binding = SharedRow::get();
+                    let mut row_builder = binding.borrow_mut();
+                    let temp_storage = RowArena::new();
 
-                // Now we need to collate them together.
-                let (oks, errs) = self.build_collation(
-                    to_collate,
-                    expr.aggregate_types,
-                    &mut collection.scope(),
-                    mfp_after,
-                );
-                errors.push(errs);
-                SpecializedArrangement::RowRow(oks)
+                    let mut row_iter = row_datums.drain(..);
+                    let mut datums_local = datums.borrow();
+                    // Unpack only the demanded columns.
+                    for skip in skips.iter() {
+                        datums_local.push(row_iter.nth(*skip).unwrap());
+                    }
+
+                    // Evaluate the key expressions.
+                    let key = match key_plan.evaluate_into(
+                        &mut datums_local,
+                        &temp_storage,
+                        &mut row_builder,
+                    ) {
+                        Err(e) => {
+                            return Some((Err(DataflowError::from(e)), time.clone(), diff.clone()))
+                        }
+                        Ok(key) => key.expect("Row expected as no predicate was used"),
+                    };
+                    // Evaluate the value expressions.
+                    // The prior evaluation may have left additional columns we should delete.
+                    datums_local.truncate(skips.len());
+                    let val = match val_plan.evaluate_iter(&mut datums_local, &temp_storage) {
+                        Err(e) => {
+                            return Some((Err(DataflowError::from(e)), time.clone(), diff.clone()))
+                        }
+                        Ok(val) => val.expect("Row expected as no predicate was used"),
+                    };
+                    row_builder.packer().extend(val);
+                    let row = row_builder.clone();
+                    Some((Ok((key, row)), time.clone(), diff.clone()))
+                }
+            });
+
+        // Demux out the potential errors from key and value selector evaluation.
+        let (ok, mut err) = key_val_input
+            .as_collection()
+            .consolidate_stream()
+            .flat_map_fallible("OkErrDemux", Some);
+
+        err = err.concat(&err_input);
+
+        // Render the reduce plan
+        self.render_reduce_plan(reduce_plan, ok, err, key_arity, mfp_after)
+            .leave_region()
+    })
+}
+
+/// Render a dataflow based on the provided plan.
+///
+/// The output will be an arrangements that looks the same as if
+/// we just had a single reduce operator computing everything together, and
+/// this arrangement can also be re-used.
+fn render_reduce_plan<S>(
+    &self,
+    plan: ReducePlan,
+    collection: Collection<S, (Row, Row), Diff>,
+    err_input: Collection<S, DataflowError, Diff>,
+    key_arity: usize,
+    mfp_after: Option<SafeMfpPlan>,
+) -> CollectionBundle<S, T>
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    let mut errors = Default::default();
+    let arrangement =
+        self.render_reduce_plan_inner(plan, collection, &mut errors, key_arity, mfp_after);
+    let errs: KeyCollection<_, _, _> = err_input.concatenate(errors).into();
+    CollectionBundle::from_columns(
+        0..key_arity,
+        ArrangementFlavor::Local(arrangement, errs.mz_arrange("Arrange bundle err")),
+    )
+}
+
+fn render_reduce_plan_inner<S>(
+    &self,
+    plan: ReducePlan,
+    collection: Collection<S, (Row, Row), Diff>,
+    errors: &mut Vec<Collection<S, DataflowError, Diff>>,
+    key_arity: usize,
+    mfp_after: Option<SafeMfpPlan>,
+) -> SpecializedArrangement<S>
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    // TODO(vmarcos): Arrangement specialization here could eventually be extended to keys,
+    // not only values (#22103).
+    let arrangement = match plan {
+        // If we have no aggregations or just a single type of reduction, we
+        // can go ahead and render them directly.
+        ReducePlan::Distinct => {
+            let (arranged_output, errs) = self.dispatch_build_distinct(collection, mfp_after);
+            errors.push(errs);
+            arranged_output
+        }
+        ReducePlan::Accumulable(expr) => {
+            let (arranged_output, errs) = self.build_accumulable(collection, expr, mfp_after);
+            errors.push(errs);
+            SpecializedArrangement::RowRow(arranged_output)
+        }
+        ReducePlan::Hierarchical(HierarchicalPlan::Monotonic(expr)) => {
+            let (output, errs) = self.build_monotonic(collection, expr, mfp_after);
+            errors.push(errs);
+            SpecializedArrangement::RowRow(output)
+        }
+        ReducePlan::Hierarchical(HierarchicalPlan::Bucketed(expr)) => {
+            let (output, errs) = self.build_bucketed(collection, expr, mfp_after);
+            errors.push(errs);
+            SpecializedArrangement::RowRow(output)
+        }
+        ReducePlan::Basic(BasicPlan::Single(index, aggr)) => {
+            let (output, errs) =
+                self.build_basic_aggregate(collection, index, &aggr, true, mfp_after);
+            errors.push(errs.expect("validation should have occurred as it was requested"));
+            SpecializedArrangement::RowRow(output)
+        }
+        ReducePlan::Basic(BasicPlan::Multiple(aggrs)) => {
+            let (output, errs) = self.build_basic_aggregates(collection, aggrs, mfp_after);
+            errors.push(errs);
+            SpecializedArrangement::RowRow(output)
+        }
+        // Otherwise, we need to render something different for each type of
+        // reduction, and then stitch them together.
+        ReducePlan::Collation(expr) => {
+            // First, we need to render our constituent aggregations.
+            let mut to_collate = vec![];
+
+            for plan in [
+                expr.hierarchical.map(ReducePlan::Hierarchical),
+                expr.accumulable.map(ReducePlan::Accumulable),
+                expr.basic.map(ReducePlan::Basic),
+            ]
+            .into_iter()
+            .flat_map(std::convert::identity)
+            {
+                let r#type = ReductionType::try_from(&plan)
+                    .expect("only representable reduction types were used above");
+
+                let arrangement = match self.render_reduce_plan_inner(
+                    plan,
+                    collection.clone(),
+                    errors,
+                    key_arity,
+                    None,
+                ) {
+                    SpecializedArrangement::RowUnit(_) => {
+                        unreachable!("Unexpected RowUnit arrangement in reduce collation rendering")
+                    }
+                    SpecializedArrangement::RowRow(arranged) => arranged,
+                };
+                to_collate.push((r#type, arrangement));
             }
-        };
-        arrangement
+
+            // Now we need to collate them together.
+            let (oks, errs) = self.build_collation(
+                to_collate,
+                expr.aggregate_types,
+                &mut collection.scope(),
+                mfp_after,
+            );
+            errors.push(errs);
+            SpecializedArrangement::RowRow(oks)
+        }
+    };
+    arrangement
+}
+
+/// Build the dataflow to combine arrangements containing results of different
+/// aggregation types into a single arrangement.
+///
+/// This computes the same thing as a join on the group key followed by shuffling
+/// the values into the correct order. This implementation assumes that all input
+/// arrangements present values in a way that respects the desired output order,
+/// so we can do a linear merge to form the output.
+fn build_collation<S>(
+    &self,
+    arrangements: Vec<(ReductionType, RowRowArrangement<S>)>,
+    aggregate_types: Vec<ReductionType>,
+    scope: &mut S,
+    mfp_after: Option<SafeMfpPlan>,
+) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    let error_logger = self.error_logger();
+
+    // We must have more than one arrangement to collate.
+    if arrangements.len() <= 1 {
+        error_logger.soft_panic_or_log(
+            "Incorrect number of arrangements in reduce collation",
+            &format!("len={}", arrangements.len()),
+        );
     }
 
-    /// Build the dataflow to combine arrangements containing results of different
-    /// aggregation types into a single arrangement.
-    ///
-    /// This computes the same thing as a join on the group key followed by shuffling
-    /// the values into the correct order. This implementation assumes that all input
-    /// arrangements present values in a way that respects the desired output order,
-    /// so we can do a linear merge to form the output.
-    fn build_collation<S>(
-        &self,
-        arrangements: Vec<(ReductionType, RowRowArrangement<S>)>,
-        aggregate_types: Vec<ReductionType>,
-        scope: &mut S,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        let error_logger = self.error_logger();
+    let mut to_concat = vec![];
 
-        // We must have more than one arrangement to collate.
-        if arrangements.len() <= 1 {
-            error_logger.soft_panic_or_log(
-                "Incorrect number of arrangements in reduce collation",
-                &format!("len={}", arrangements.len()),
-            );
-        }
+    // First, lets collect all results into a single collection.
+    for (reduction_type, arrangement) in arrangements.into_iter() {
+        let collection = arrangement
+            .as_collection(move |key, val| (key.into_owned(), (reduction_type, val.into_owned())));
+        to_concat.push(collection);
+    }
 
-        let mut to_concat = vec![];
+    // For each key above, we need to have exactly as many rows as there are distinct
+    // reduction types required by `aggregate_types`. We thus prepare here a properly
+    // deduplicated version of `aggregate_types` for validation during processing below.
+    let mut distinct_aggregate_types = aggregate_types.clone();
+    distinct_aggregate_types.sort_unstable();
+    distinct_aggregate_types.dedup();
+    let n_distinct_aggregate_types = distinct_aggregate_types.len();
 
-        // First, lets collect all results into a single collection.
-        for (reduction_type, arrangement) in arrangements.into_iter() {
-            let collection = arrangement.as_collection(move |key, val| {
-                (key.into_owned(), (reduction_type, val.into_owned()))
-            });
-            to_concat.push(collection);
-        }
+    // Allocations for the two closures.
+    let mut datums1 = DatumVec::new();
+    let mut datums2 = DatumVec::new();
+    let mfp_after1 = mfp_after.clone();
+    let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
 
-        // For each key above, we need to have exactly as many rows as there are distinct
-        // reduction types required by `aggregate_types`. We thus prepare here a properly
-        // deduplicated version of `aggregate_types` for validation during processing below.
-        let mut distinct_aggregate_types = aggregate_types.clone();
-        distinct_aggregate_types.sort_unstable();
-        distinct_aggregate_types.dedup();
-        let n_distinct_aggregate_types = distinct_aggregate_types.len();
-
-        // Allocations for the two closures.
-        let mut datums1 = DatumVec::new();
-        let mut datums2 = DatumVec::new();
-        let mfp_after1 = mfp_after.clone();
-        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
-
-        let aggregate_types_err = aggregate_types.clone();
-        let (oks, errs) = differential_dataflow::collection::concatenate(scope, to_concat)
-            .mz_arrange::<RowValSpine<_, _, _>>("Arrange ReduceCollation")
-            .reduce_pair::<_, RowRowSpine<_, _>, _, RowErrSpine<_, _>>(
-                "ReduceCollation",
-                "ReduceCollation Errors",
-                {
-                    move |key, input, output| {
-                        // The inputs are pairs of a reduction type, and a row consisting of densely
-                        // packed fused aggregate values.
-                        //
-                        // We need to reconstitute the final value by:
-                        // 1. Extracting out the fused rows by type
-                        // 2. For each aggregate, figure out what type it is, and grab the relevant
-                        //    value from the corresponding fused row.
-                        // 3. Stitch all the values together into one row.
-                        let mut accumulable = DatumList::empty().iter();
-                        let mut hierarchical = DatumList::empty().iter();
-                        let mut basic = DatumList::empty().iter();
-
-                        // Note that hierarchical and basic reductions guard against negative
-                        // multiplicities, and if we only had accumulable aggregations, we would not
-                        // have produced a collation plan, so we do not repeat the check here.
-                        if input.len() != n_distinct_aggregate_types {
-                            return;
-                        }
-
-                        for (item, _) in input.iter() {
-                            let reduction_type = &item.0;
-                            let row = &item.1;
-                            match reduction_type {
-                                ReductionType::Accumulable => accumulable = row.iter(),
-                                ReductionType::Hierarchical => hierarchical = row.iter(),
-                                ReductionType::Basic => basic = row.iter(),
-                            }
-                        }
-
-                        let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
-                        let mut datums_local = datums1.borrow();
-                        datums_local.extend(datum_iter);
-                        let key_len = datums_local.len();
-
-                        // Merge results into the order they were asked for.
-                        for typ in aggregate_types.iter() {
-                            let datum = match typ {
-                                ReductionType::Accumulable => accumulable.next(),
-                                ReductionType::Hierarchical => hierarchical.next(),
-                                ReductionType::Basic => basic.next(),
-                            };
-                            let Some(datum) = datum else { return };
-                            datums_local.push(datum);
-                        }
-
-                        // If we did not have enough values to stitch together, then we do not
-                        // generate an output row. Not outputting here corresponds to the semantics
-                        // of an equi-join on the key, similarly to the proposal in PR #17013.
-                        //
-                        // Note that we also do not want to have anything left over to stich. If we
-                        // do, then we also have an error, reported elsewhere, and would violate
-                        // join semantics.
-                        if (accumulable.next(), hierarchical.next(), basic.next())
-                            == (None, None, None)
-                        {
-                            if let Some(row) = evaluate_mfp_after(
-                                &mfp_after1,
-                                &mut datums_local,
-                                &temp_storage,
-                                key_len,
-                            ) {
-                                output.push((row, 1));
-                            }
-                        }
-                    }
-                },
+    let aggregate_types_err = aggregate_types.clone();
+    let (oks, errs) = differential_dataflow::collection::concatenate(scope, to_concat)
+        .mz_arrange::<RowValSpine<_, _, _>>("Arrange ReduceCollation")
+        .reduce_pair::<_, RowRowSpine<_, _>, _, RowErrSpine<_, _>>(
+            "ReduceCollation",
+            "ReduceCollation Errors",
+            {
                 move |key, input, output| {
-                    if input.len() != n_distinct_aggregate_types {
-                        // We expected to stitch together exactly as many aggregate types as requested
-                        // by the collation. If we cannot, we log an error and produce no output for
-                        // this key.
-                        let message = "Mismatched aggregates for key in ReduceCollation";
-                        error_logger.log(
-                            message,
-                            &format!(
-                                "key={key:?}, n_aggregates_requested={requested}, \
-                                 n_distinct_aggregate_types={n_distinct_aggregate_types}",
-                                requested = input.len(),
-                            ),
-                        );
-                        output.push((EvalError::Internal(message.to_string()).into(), 1));
-                        return;
-                    }
-
+                    // The inputs are pairs of a reduction type, and a row consisting of densely
+                    // packed fused aggregate values.
+                    //
+                    // We need to reconstitute the final value by:
+                    // 1. Extracting out the fused rows by type
+                    // 2. For each aggregate, figure out what type it is, and grab the relevant
+                    //    value from the corresponding fused row.
+                    // 3. Stitch all the values together into one row.
                     let mut accumulable = DatumList::empty().iter();
                     let mut hierarchical = DatumList::empty().iter();
                     let mut basic = DatumList::empty().iter();
+
+                    // Note that hierarchical and basic reductions guard against negative
+                    // multiplicities, and if we only had accumulable aggregations, we would not
+                    // have produced a collation plan, so we do not repeat the check here.
+                    if input.len() != n_distinct_aggregate_types {
+                        return;
+                    }
+
                     for (item, _) in input.iter() {
                         let reduction_type = &item.0;
                         let row = &item.1;
@@ -444,998 +364,30 @@ where
 
                     let temp_storage = RowArena::new();
                     let datum_iter = key.into_datum_iter(None);
-                    let mut datums_local = datums2.borrow();
+                    let mut datums_local = datums1.borrow();
                     datums_local.extend(datum_iter);
+                    let key_len = datums_local.len();
 
-                    for typ in aggregate_types_err.iter() {
+                    // Merge results into the order they were asked for.
+                    for typ in aggregate_types.iter() {
                         let datum = match typ {
                             ReductionType::Accumulable => accumulable.next(),
                             ReductionType::Hierarchical => hierarchical.next(),
                             ReductionType::Basic => basic.next(),
                         };
-                        if let Some(datum) = datum {
-                            datums_local.push(datum);
-                        } else {
-                            // We cannot properly reconstruct a row if aggregates are missing.
-                            // This situation is not expected, so we log an error if it occurs.
-                            let message = "Missing value for key in ReduceCollation";
-                            error_logger.log(message, &format!("typ={typ:?}, key={key:?}"));
-                            output.push((EvalError::Internal(message.to_string()).into(), 1));
-                            return;
-                        }
+                        let Some(datum) = datum else { return };
+                        datums_local.push(datum);
                     }
 
-                    // Note that we also do not want to have anything left over to stich.
-                    // If we do, then we also have an error and would violate join semantics.
-                    if (accumulable.next(), hierarchical.next(), basic.next()) != (None, None, None)
+                    // If we did not have enough values to stitch together, then we do not
+                    // generate an output row. Not outputting here corresponds to the semantics
+                    // of an equi-join on the key, similarly to the proposal in PR #17013.
+                    //
+                    // Note that we also do not want to have anything left over to stich. If we
+                    // do, then we also have an error, reported elsewhere, and would violate
+                    // join semantics.
+                    if (accumulable.next(), hierarchical.next(), basic.next()) == (None, None, None)
                     {
-                        let message = "Rows too large for key in ReduceCollation";
-                        error_logger.log(message, &format!("key={key:?}"));
-                        output.push((EvalError::Internal(message.to_string()).into(), 1));
-                    }
-
-                    // Finally, if `mfp_after` can produce errors, then we should also report
-                    // these here.
-                    let Some(mfp) = &mfp_after2 else { return };
-                    if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
-                        output.push((e.into(), 1));
-                    }
-                },
-            );
-        (oks, errs.as_collection(|_, v| v.into_owned()))
-    }
-
-    fn dispatch_build_distinct<S>(
-        &self,
-        collection: Collection<S, (Row, Row), Diff>,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> (
-        SpecializedArrangement<S>,
-        Collection<S, DataflowError, Diff>,
-    )
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        if self.enable_specialized_arrangements {
-            let collection = collection.map(|(k, v)| {
-                assert!(v.is_empty());
-                (k, ())
-            });
-            let (arrangement, errs) = self
-                .build_distinct::<RowSpine<_, _>, RowValSpine<_, _, _>, _>(
-                    collection,
-                    " [val: empty]",
-                    mfp_after,
-                );
-            (SpecializedArrangement::RowUnit(arrangement), errs)
-        } else {
-            let collection = collection.inspect(|((_, v), _, _)| assert!(v.is_empty()));
-            let (arrangement, errs) = self
-                .build_distinct::<RowRowSpine<_, _>, RowValSpine<_, _, _>, _>(
-                    collection, "", mfp_after,
-                );
-            (SpecializedArrangement::RowRow(arrangement), errs)
-        }
-    }
-
-    /// Build the dataflow to compute the set of distinct keys.
-    fn build_distinct<T1, T2, S>(
-        &self,
-        collection: Collection<S, (Row, T1::ValOwned), Diff>,
-        tag: &str,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> (
-        Arranged<S, TraceAgent<T1>>,
-        Collection<S, DataflowError, Diff>,
-    )
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-        T1: Trace<KeyOwned = Row, Time = G::Timestamp, Diff = Diff> + 'static,
-        T1::Batch: Batch,
-        T1::Batcher: Batcher<Item = ((Row, T1::ValOwned), G::Timestamp, Diff)>,
-        for<'a> T1::Key<'a>: std::fmt::Debug + IntoRowByTypes,
-        T1::ValOwned: Columnation + ExchangeData + Default,
-        Arranged<S, TraceAgent<T1>>: ArrangementSize,
-        T2: for<'a> Trace<
-                Key<'a> = T1::Key<'a>,
-                KeyOwned = Row,
-                ValOwned = DataflowError,
-                Time = G::Timestamp,
-                Diff = Diff,
-            > + 'static,
-        T2::Batch: Batch,
-        T2::Batcher: Batcher<Item = ((Row, T2::ValOwned), G::Timestamp, Diff)>,
-        Arranged<S, TraceAgent<T2>>: ArrangementSize,
-    {
-        let error_logger = self.error_logger();
-
-        let (input_name, output_name) = (
-            format!("Arranged DistinctBy{}", tag),
-            format!("DistinctBy{}", tag),
-        );
-
-        // Allocations for the two closures.
-        let mut datums1 = DatumVec::new();
-        let mut datums2 = DatumVec::new();
-        let mfp_after1 = mfp_after.clone();
-        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
-
-        let (output, errors) = collection
-            .mz_arrange::<T1>(&input_name)
-            .reduce_pair::<_, T1, _, T2>(
-                &output_name,
-                "DistinctByErrorCheck",
-                move |key, _input, output| {
-                    let temp_storage = RowArena::new();
-                    let mut datums_local = datums1.borrow();
-                    datums_local.extend(key.into_datum_iter(None));
-
-                    // Note that the key contains all the columns in a `Distinct` and that `mfp_after` is
-                    // required to preserve the key. Therefore, if `mfp_after` maps, then it must project
-                    // back to the key. As a consequence, we can treat `mfp_after` as a filter here.
-                    if mfp_after1
-                        .as_ref()
-                        .map(|mfp| mfp.evaluate_inner(&mut datums_local, &temp_storage))
-                        .unwrap_or(Ok(true))
-                        == Ok(true)
-                    {
-                        // We're pushing a unit value here because the key is implicitly added by the
-                        // arrangement, and the permutation logic takes care of using the key part of the
-                        // output.
-                        output.push((T1::ValOwned::default(), 1));
-                    }
-                },
-                move |key, input: &[(_, Diff)], output| {
-                    for (_, count) in input.iter() {
-                        if count.is_positive() {
-                            continue;
-                        }
-                        let message = "Non-positive multiplicity in DistinctBy";
-                        error_logger.log(message, &format!("row={key:?}, count={count}"));
-                        output.push((EvalError::Internal(message.to_string()).into(), 1));
-                        return;
-                    }
-                    // If `mfp_after` can error, then evaluate it here.
-                    let Some(mfp) = &mfp_after2 else { return };
-                    let temp_storage = RowArena::new();
-                    let datum_iter = key.into_datum_iter(None);
-                    let mut datums_local = datums2.borrow();
-                    datums_local.extend(datum_iter);
-
-                    if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
-                        output.push((e.into(), 1));
-                    }
-                },
-            );
-        (output, errors.as_collection(|_k, v| v.into_owned()))
-    }
-
-    /// Build the dataflow to compute and arrange multiple non-accumulable,
-    /// non-hierarchical aggregations on `input`.
-    ///
-    /// This function assumes that we are explicitly rendering multiple basic aggregations.
-    /// For each aggregate, we render a different reduce operator, and then fuse
-    /// results together into a final arrangement that presents all the results
-    /// in the order specified by `aggrs`.
-    fn build_basic_aggregates<S>(
-        &self,
-        input: Collection<S, (Row, Row), Diff>,
-        aggrs: Vec<(usize, AggregateExpr)>,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        // We are only using this function to render multiple basic aggregates and
-        // stitch them together. If that's not true we should complain.
-        if aggrs.len() <= 1 {
-            self.error_logger().soft_panic_or_log(
-                "Too few aggregations when building basic aggregates",
-                &format!("len={}", aggrs.len()),
-            )
-        }
-        let mut err_output = None;
-        let mut to_collect = Vec::new();
-        for (index, aggr) in aggrs {
-            let (result, errs) =
-                self.build_basic_aggregate(input.clone(), index, &aggr, err_output.is_none(), None);
-            if errs.is_some() {
-                err_output = errs
-            }
-            to_collect.push(
-                result.as_collection(move |key, val| (key.into_owned(), (index, val.into_owned()))),
-            );
-        }
-
-        // Allocations for the two closures.
-        let mut datums1 = DatumVec::new();
-        let mut datums2 = DatumVec::new();
-        let mfp_after1 = mfp_after.clone();
-        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
-
-        let arranged =
-            differential_dataflow::collection::concatenate(&mut input.scope(), to_collect)
-                .mz_arrange::<RowValSpine<_, _, _>>("Arranged ReduceFuseBasic input");
-
-        let output = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceFuseBasic", {
-            move |key, input, output| {
-                let temp_storage = RowArena::new();
-                let datum_iter = key.into_datum_iter(None);
-                let mut datums_local = datums1.borrow();
-                datums_local.extend(datum_iter);
-                let key_len = datums_local.len();
-
-                for ((_, row), _) in input.iter() {
-                    datums_local.push(row.unpack_first());
-                }
-
-                if let Some(row) =
-                    evaluate_mfp_after(&mfp_after1, &mut datums_local, &temp_storage, key_len)
-                {
-                    output.push((row, 1));
-                }
-            }
-        });
-        // If `mfp_after` can error, then we need to render a paired reduction
-        // to scan for these potential errors. Note that we cannot directly use
-        // `mz_timely_util::reduce::ReduceExt::reduce_pair` here because we only
-        // conditionally render the second component of the reduction pair.
-        let validation_errs = err_output.expect("expected to validate in at least one aggregate");
-        if let Some(mfp) = mfp_after2 {
-            let mfp_errs = arranged
-                .mz_reduce_abelian::<_, RowErrSpine<_, _>>(
-                    "ReduceFuseBasic Error Check",
-                    move |key, input, output| {
-                        // Since negative accumulations are checked in at least one component
-                        // aggregate, we only need to look for MFP errors here.
-                        let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
-                        let mut datums_local = datums2.borrow();
-                        datums_local.extend(datum_iter);
-
-                        for ((_, row), _) in input.iter() {
-                            datums_local.push(row.unpack_first());
-                        }
-
-                        if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
-                        {
-                            output.push((e.into(), 1));
-                        }
-                    },
-                )
-                .as_collection(|_, v| v.into_owned());
-            (output, validation_errs.concat(&mfp_errs))
-        } else {
-            (output, validation_errs)
-        }
-    }
-
-    /// Build the dataflow to compute a single basic aggregation.
-    ///
-    /// This method also applies distinctness if required.
-    fn build_basic_aggregate<S>(
-        &self,
-        input: Collection<S, (Row, Row), Diff>,
-        index: usize,
-        aggr: &AggregateExpr,
-        validating: bool,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> (
-        RowRowArrangement<S>,
-        Option<Collection<S, DataflowError, Diff>>,
-    )
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        let AggregateExpr {
-            func,
-            expr: _,
-            distinct,
-        } = aggr.clone();
-
-        // Extract the value we were asked to aggregate over.
-        let mut partial = input.map(move |(key, row)| {
-            let binding = SharedRow::get();
-            let mut row_builder = binding.borrow_mut();
-            let value = row.iter().nth(index).unwrap();
-            row_builder.packer().push(value);
-            (key, row_builder.clone())
-        });
-
-        let mut err_output = None;
-
-        // If `distinct` is set, we restrict ourselves to the distinct `(key, val)`.
-        if distinct {
-            if validating {
-                let (oks, errs) = self
-                    .build_reduce_inaccumulable_distinct::<_, KeyValSpine<_, Result<(), String>, _, _>>(partial, None)
-                    .as_collection(|k, v| (k.into_owned(), v.into_owned()))
-                    .map_fallible("Demux Errors", move |(key, result)| match result {
-                        Ok(()) => Ok(key),
-                        Err(m) => Err(EvalError::Internal(m).into()),
-                    });
-                err_output = Some(errs);
-                partial = oks;
-            } else {
-                partial = self
-                    .build_reduce_inaccumulable_distinct::<_, KeySpine<_, _, _>>(
-                        partial,
-                        Some(" [val: empty]"),
-                    )
-                    .as_collection(|k, _| k.into_owned());
-            }
-        }
-
-        // Allocations for the two closures.
-        let mut datums1 = DatumVec::new();
-        let mut datums2 = DatumVec::new();
-        let mfp_after1 = mfp_after.clone();
-        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
-        let func2 = func.clone();
-
-        let arranged = partial.mz_arrange::<RowRowSpine<_, _>>("Arranged ReduceInaccumulable");
-        let oks = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceInaccumulable", {
-            move |key, source, target| {
-                // We respect the multiplicity here (unlike in hierarchical aggregation)
-                // because we don't know that the aggregation method is not sensitive
-                // to the number of records.
-                let iter = source.iter().flat_map(|(v, w)| {
-                    // Note that in the non-positive case, this is wrong, but harmless because
-                    // our other reduction will produce an error.
-                    let count = usize::try_from(*w).unwrap_or(0);
-                    std::iter::repeat(v.into_datum_iter(None).next().unwrap()).take(count)
-                });
-
-                let temp_storage = RowArena::new();
-                let datum_iter = key.into_datum_iter(None);
-                let mut datums_local = datums1.borrow();
-                datums_local.extend(datum_iter);
-                let key_len = datums_local.len();
-                datums_local.push(
-                    // Note that this is not necessarily a window aggregation, in which case
-                    // `eval_fast_window_agg` delegates to the normal `eval`.
-                    func.eval_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
-                        iter,
-                        &temp_storage,
-                    ),
-                );
-
-                if let Some(row) =
-                    evaluate_mfp_after(&mfp_after1, &mut datums_local, &temp_storage, key_len)
-                {
-                    target.push((row, 1));
-                }
-            }
-        });
-
-        // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here, but
-        // we then wouldn't be able to do this error check conditionally.  See its documentation for the
-        // rationale around using a second reduction here.
-        let must_validate = validating && err_output.is_none();
-        if must_validate || mfp_after2.is_some() {
-            let error_logger = self.error_logger();
-
-            let errs = arranged
-                .mz_reduce_abelian::<_, RowErrSpine<_, _>>(
-                    "ReduceInaccumulable Error Check",
-                    move |key, source, target| {
-                        // Negative counts would be surprising, but until we are 100% certain we won't
-                        // see them, we should report when we do. We may want to bake even more info
-                        // in here in the future.
-                        if must_validate {
-                            for (value, count) in source.iter() {
-                                if count.is_positive() {
-                                    continue;
-                                }
-                                let value = value.into_owned();
-                                let message = "Non-positive accumulation in ReduceInaccumulable";
-                                error_logger
-                                    .log(message, &format!("value={value:?}, count={count}"));
-                                target.push((EvalError::Internal(message.to_string()).into(), 1));
-                                return;
-                            }
-                        }
-
-                        // We know that `mfp_after` can error if it exists, so try to evaluate it here.
-                        let Some(mfp) = &mfp_after2 else { return };
-                        let iter = source.iter().flat_map(|(mut v, w)| {
-                            let count = usize::try_from(*w).unwrap_or(0);
-                            // This would ideally use `into_datum_iter` but we cannot as it needs to
-                            // borrow `v` and only presents datums with that lifetime, not any longer.
-                            std::iter::repeat(v.next().unwrap()).take(count)
-                        });
-
-                        let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
-                        let mut datums_local = datums2.borrow();
-                        datums_local.extend(datum_iter);
-                        datums_local.push(
-                            func2.eval_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
-                                iter,
-                                &temp_storage,
-                            ),
-                        );
-                        if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
-                        {
-                            target.push((e.into(), 1));
-                        }
-                    },
-                )
-                .as_collection(|_, v| v.into_owned());
-            if let Some(e) = err_output {
-                err_output = Some(e.concat(&errs));
-            } else {
-                err_output = Some(errs);
-            }
-        }
-        (oks, err_output)
-    }
-
-    fn build_reduce_inaccumulable_distinct<S, Tr>(
-        &self,
-        input: Collection<S, (Row, Row), Diff>,
-        name_tag: Option<&str>,
-    ) -> Arranged<S, TraceAgent<Tr>>
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-        Tr::ValOwned: MaybeValidatingRow<(), String>,
-        Tr: Trace
-            + for<'a> TraceReader<
-                Key<'a> = &'a (Row, Row),
-                KeyOwned = (Row, Row),
-                Time = G::Timestamp,
-                Diff = Diff,
-            > + 'static,
-        Tr::Batch: Batch,
-        Tr::Batcher: Batcher<Item = (((Row, Row), Tr::ValOwned), G::Timestamp, Diff)>,
-        Arranged<S, TraceAgent<Tr>>: ArrangementSize,
-    {
-        let error_logger = self.error_logger();
-
-        let output_name = format!(
-            "ReduceInaccumulable Distinct{}",
-            name_tag.unwrap_or_default()
-        );
-
-        let input: KeyCollection<_, _, _> = input.into();
-        input
-            .mz_arrange::<KeySpine<(Row, Row), _, _>>(
-                "Arranged ReduceInaccumulable Distinct [val: empty]",
-            )
-            .mz_reduce_abelian::<_, Tr>(&output_name, move |_, source, t| {
-                if let Some(err) = Tr::ValOwned::into_error() {
-                    for (value, count) in source.iter() {
-                        if count.is_positive() {
-                            continue;
-                        }
-
-                        let message = "Non-positive accumulation in ReduceInaccumulable DISTINCT";
-                        error_logger.log(message, &format!("value={value:?}, count={count}"));
-                        t.push((err(message.to_string()), 1));
-                        return;
-                    }
-                }
-                t.push((Tr::ValOwned::ok(()), 1))
-            })
-    }
-
-    /// Build the dataflow to compute and arrange multiple hierarchical aggregations
-    /// on non-monotonic inputs.
-    ///
-    /// This function renders a single reduction tree that computes aggregations with
-    /// a priority queue implemented with a series of reduce operators that partition
-    /// the input into buckets, and compute the aggregation over very small buckets
-    /// and feed the results up to larger buckets.
-    ///
-    /// Note that this implementation currently ignores the distinct bit because we
-    /// currently only perform min / max hierarchically and the reduction tree
-    /// efficiently suppresses non-distinct updates.
-    fn build_bucketed<S>(
-        &self,
-        input: Collection<S, (Row, Row), Diff>,
-        BucketedPlan {
-            aggr_funcs,
-            skips,
-            buckets,
-        }: BucketedPlan,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        let mut err_output: Option<Collection<S, _, _>> = None;
-        let arranged_output = input.scope().region_named("ReduceHierarchical", |inner| {
-            let input = input.enter(inner);
-
-            // Gather the relevant values into a vec of rows ordered by aggregation_index
-            let input = input.map(move |(key, row)| {
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
-                let mut values = Vec::with_capacity(skips.len());
-                let mut row_iter = row.iter();
-                for skip in skips.iter() {
-                    row_builder.packer().push(row_iter.nth(*skip).unwrap());
-                    values.push(row_builder.clone());
-                }
-
-                (key, values)
-            });
-
-            // Repeatedly apply hierarchical reduction with a progressively coarser key.
-            let mut stage = input.map(move |(key, values)| ((key, values.hashed()), values));
-            for b in buckets.into_iter() {
-                let input = stage.map(move |((key, hash), values)| ((key, hash % b), values));
-
-                // We only want the first stage to perform validation of whether invalid accumulations
-                // were observed in the input. Subsequently, we will either produce an error in the error
-                // stream or produce correct data in the output stream.
-                let negated_output = if err_output.is_none() {
-                    let (oks, errs) = self
-                        .build_bucketed_negated_output::<_, Result<Vec<Row>, (Row, u64)>>(
-                            &input,
-                            aggr_funcs.clone(),
-                        )
-                        .map_fallible(
-                            "Checked Invalid Accumulations",
-                            |(key, result)| match result {
-                                Err((key, _)) => {
-                                    let message = format!(
-                                        "Invalid data in source, saw non-positive accumulation \
-                                         for key {key:?} in hierarchical mins-maxes aggregate"
-                                    );
-                                    Err(EvalError::Internal(message).into())
-                                }
-                                Ok(values) => Ok((key, values)),
-                            },
-                        );
-                    err_output = Some(errs.leave_region());
-                    oks
-                } else {
-                    self.build_bucketed_negated_output::<_, Vec<Row>>(&input, aggr_funcs.clone())
-                };
-
-                stage = negated_output
-                    .negate()
-                    .concat(&input)
-                    .consolidate_named::<KeySpine<_, _, _>>("Consolidated MinsMaxesHierarchical");
-            }
-
-            // Discard the hash from the key and return to the format of the input data.
-            let partial = stage.map(|((key, _hash), values)| (key, values));
-
-            // Allocations for the two closures.
-            let mut datums1 = DatumVec::new();
-            let mut datums2 = DatumVec::new();
-            let mfp_after1 = mfp_after.clone();
-            let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
-            let aggr_funcs2 = aggr_funcs.clone();
-
-            // Build a series of stages for the reduction
-            // Arrange the final result into (key, Row)
-            let error_logger = self.error_logger();
-            // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
-            // view mz_internal.mz_expected_group_size_advice.
-            let arranged =
-                partial.mz_arrange::<RowValSpine<Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
-            // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
-            // but we then wouldn't be able to do this error check conditionally.  See its documentation
-            // for the rationale around using a second reduction here.
-            let must_validate = err_output.is_none();
-            if must_validate || mfp_after2.is_some() {
-                let errs = arranged
-                    .mz_reduce_abelian::<_, RowErrSpine<_, _>>(
-                        "ReduceMinsMaxes Error Check",
-                        move |key, source, target| {
-                            // Negative counts would be surprising, but until we are 100% certain we wont
-                            // see them, we should report when we do. We may want to bake even more info
-                            // in here in the future.
-                            if must_validate {
-                                for (val, count) in source.iter() {
-                                    if count.is_positive() {
-                                        continue;
-                                    }
-                                    let val = val.into_owned();
-                                    let message = "Non-positive accumulation in ReduceMinsMaxes";
-                                    error_logger
-                                        .log(message, &format!("val={val:?}, count={count}"));
-                                    target
-                                        .push((EvalError::Internal(message.to_string()).into(), 1));
-                                    return;
-                                }
-                            }
-
-                            // We know that `mfp_after` can error if it exists, so try to evaluate it here.
-                            let Some(mfp) = &mfp_after2 else { return };
-                            let temp_storage = RowArena::new();
-                            let datum_iter = key.into_datum_iter(None);
-                            let mut datums_local = datums2.borrow();
-                            datums_local.extend(datum_iter);
-                            for (aggr_index, func) in aggr_funcs2.iter().enumerate() {
-                                let iter = source.iter().map(|(values, _cnt)| {
-                                    values[aggr_index].iter().next().unwrap()
-                                });
-                                datums_local.push(func.eval(iter, &temp_storage));
-                            }
-                            if let Result::Err(e) =
-                                mfp.evaluate_inner(&mut datums_local, &temp_storage)
-                            {
-                                target.push((e.into(), 1));
-                            }
-                        },
-                    )
-                    .as_collection(|_, v| v.into_owned())
-                    .leave_region();
-                if let Some(e) = &err_output {
-                    err_output = Some(e.concat(&errs));
-                } else {
-                    err_output = Some(errs);
-                }
-            }
-            arranged
-                .mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMinsMaxes", {
-                    move |key, source, target| {
-                        let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
-                        let mut datums_local = datums1.borrow();
-                        datums_local.extend(datum_iter);
-                        let key_len = datums_local.len();
-                        for (aggr_index, func) in aggr_funcs.iter().enumerate() {
-                            let iter = source
-                                .iter()
-                                .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
-                            datums_local.push(func.eval(iter, &temp_storage));
-                        }
-
-                        if let Some(row) = evaluate_mfp_after(
-                            &mfp_after1,
-                            &mut datums_local,
-                            &temp_storage,
-                            key_len,
-                        ) {
-                            target.push((row, 1));
-                        }
-                    }
-                })
-                .leave_region()
-        });
-        (
-            arranged_output,
-            err_output.expect("expected to validate in one level of the hierarchy"),
-        )
-    }
-
-    /// Build the dataflow for one stage of a reduction tree for multiple hierarchical
-    /// aggregates.
-    ///
-    /// `buckets` indicates the number of buckets in this stage. We do some non
-    /// obvious trickery here to limit the memory usage per layer by internally
-    /// holding only the elements that were rejected by this stage. However, the
-    /// output collection maintains the `((key, bucket), (passing value)` for this
-    /// stage.
-    /// `validating` indicates whether we want this stage to perform error detection
-    /// for invalid accumulations. Once a stage is clean of such errors, subsequent
-    /// stages can skip validation.
-    fn build_bucketed_negated_output<S, R>(
-        &self,
-        input: &Collection<S, ((Row, u64), Vec<Row>), Diff>,
-        aggrs: Vec<AggregateFunc>,
-    ) -> Collection<S, ((Row, u64), R), Diff>
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-        R: MaybeValidatingRow<Vec<Row>, (Row, u64)>,
-    {
-        let error_logger = self.error_logger();
-        // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
-        // view mz_internal.mz_expected_group_size_advice.
-        let arranged_input = input
-            .mz_arrange::<KeyValSpine<_, Vec<Row>, _, _>>("Arranged MinsMaxesHierarchical input");
-
-        arranged_input
-            .mz_reduce_abelian::<_, KeyValSpine<_, _, _, _>>(
-                "Reduced Fallibly MinsMaxesHierarchical",
-                move |key, source, target| {
-                    if let Some(err) = R::into_error() {
-                        // Should negative accumulations reach us, we should loudly complain.
-                        for (value, count) in source.iter() {
-                            if count.is_positive() {
-                                continue;
-                            }
-                            error_logger.log(
-                                "Non-positive accumulation in MinsMaxesHierarchical",
-                                &format!("key={key:?}, value={value:?}, count={count}"),
-                            );
-                            // After complaining, output an error here so that we can eventually
-                            // report it in an error stream.
-                            target.push((err(key.clone()), -1));
-                            return;
-                        }
-                    }
-                    let binding = SharedRow::get();
-                    let mut row_builder = binding.borrow_mut();
-                    let mut output = Vec::with_capacity(aggrs.len());
-                    for (aggr_index, func) in aggrs.iter().enumerate() {
-                        let iter = source
-                            .iter()
-                            .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
-                        row_builder.packer().push(func.eval(iter, &RowArena::new()));
-                        output.push(row_builder.clone());
-                    }
-                    // We only want to arrange the parts of the input that are not part of the output.
-                    // More specifically, we want to arrange it so that `input.concat(&output.negate())`
-                    // gives us the intended value of this aggregate function. Also we assume that regardless
-                    // of the multiplicity of the final result in the input, we only want to have one copy
-                    // in the output.
-                    target.push((R::ok(output), -1));
-                    target.extend(
-                        source
-                            .iter()
-                            .map(|(values, cnt)| (R::ok((*values).clone()), *cnt)),
-                    );
-                },
-            )
-            .as_collection(|k, v| (k.clone(), v.clone()))
-    }
-
-    /// Build the dataflow to compute and arrange multiple hierarchical aggregations
-    /// on monotonic inputs.
-    fn build_monotonic<S>(
-        &self,
-        collection: Collection<S, (Row, Row), Diff>,
-        MonotonicPlan {
-            aggr_funcs,
-            skips,
-            must_consolidate,
-        }: MonotonicPlan,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        // Gather the relevant values into a vec of rows ordered by aggregation_index
-        let collection = collection
-            .map(move |(key, row)| {
-                let binding = SharedRow::get();
-                let mut row_builder = binding.borrow_mut();
-                let mut values = Vec::with_capacity(skips.len());
-                let mut row_iter = row.iter();
-                for skip in skips.iter() {
-                    row_builder.packer().push(row_iter.nth(*skip).unwrap());
-                    values.push(row_builder.clone());
-                }
-
-                (key, values)
-            })
-            .consolidate_named_if::<KeySpine<_, _, _>>(
-                must_consolidate,
-                "Consolidated ReduceMonotonic input",
-            );
-
-        // It should be now possible to ensure that we have a monotonic collection.
-        let error_logger = self.error_logger();
-        let (partial, validation_errs) = collection.ensure_monotonic(move |data, diff| {
-            error_logger.log(
-                "Non-monotonic input to ReduceMonotonic",
-                &format!("data={data:?}, diff={diff}"),
-            );
-            let m = "tried to build a monotonic reduction on non-monotonic input".to_string();
-            (EvalError::Internal(m).into(), 1)
-        });
-        // We can place our rows directly into the diff field, and
-        // only keep the relevant one corresponding to evaluating our
-        // aggregate, instead of having to do a hierarchical reduction.
-        let partial = partial.explode_one(move |(key, values)| {
-            let mut output = Vec::new();
-            for (row, func) in values.into_iter().zip(aggr_funcs.iter()) {
-                output.push(monoids::get_monoid(row, func).expect(
-                    "hierarchical aggregations are expected to have monoid implementations",
-                ));
-            }
-            (key, output)
-        });
-
-        // Allocations for the two closures.
-        let mut datums1 = DatumVec::new();
-        let mut datums2 = DatumVec::new();
-        let mfp_after1 = mfp_after.clone();
-        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
-
-        let partial: KeyCollection<_, _, _> = partial.into();
-        let arranged = partial
-            .mz_arrange::<RowSpine<_, Vec<ReductionMonoid>>>("ArrangeMonotonic [val: empty]");
-        let output = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMonotonic", {
-            move |key, input, output| {
-                let temp_storage = RowArena::new();
-                let datum_iter = key.into_datum_iter(None);
-                let mut datums_local = datums1.borrow();
-                datums_local.extend(datum_iter);
-                let key_len = datums_local.len();
-                let accum = &input[0].1;
-                for monoid in accum.iter() {
-                    datums_local.extend(monoid.finalize().iter());
-                }
-
-                if let Some(row) =
-                    evaluate_mfp_after(&mfp_after1, &mut datums_local, &temp_storage, key_len)
-                {
-                    output.push((row, 1));
-                }
-            }
-        });
-
-        // If `mfp_after` can error, then we need to render a paired reduction
-        // to scan for these potential errors. Note that we cannot directly use
-        // `mz_timely_util::reduce::ReduceExt::reduce_pair` here because we only
-        // conditionally render the second component of the reduction pair.
-        if let Some(mfp) = mfp_after2 {
-            let mfp_errs = arranged
-                .mz_reduce_abelian::<_, RowErrSpine<_, _>>("ReduceMonotonic Error Check", {
-                    move |key, input, output| {
-                        let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
-                        let mut datums_local = datums2.borrow();
-                        datums_local.extend(datum_iter);
-                        let accum = &input[0].1;
-                        for monoid in accum.iter() {
-                            datums_local.extend(monoid.finalize().iter());
-                        }
-                        if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
-                        {
-                            output.push((e.into(), 1));
-                        }
-                    }
-                })
-                .as_collection(|_k, v| v.clone());
-            (output, validation_errs.concat(&mfp_errs))
-        } else {
-            (output, validation_errs)
-        }
-    }
-
-    /// Build the dataflow to compute and arrange multiple accumulable aggregations.
-    ///
-    /// The incoming values are moved to the update's "difference" field, at which point
-    /// they can be accumulated in place. The `count` operator promotes the accumulated
-    /// values to data, at which point a final map applies operator-specific logic to
-    /// yield the final aggregate.
-    fn build_accumulable<S>(
-        &self,
-        collection: Collection<S, (Row, Row), Diff>,
-        AccumulablePlan {
-            full_aggrs,
-            simple_aggrs,
-            distinct_aggrs,
-        }: AccumulablePlan,
-        mfp_after: Option<SafeMfpPlan>,
-    ) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        // we must have called this function with something to reduce
-        if full_aggrs.len() == 0 || simple_aggrs.len() + distinct_aggrs.len() != full_aggrs.len() {
-            self.error_logger().soft_panic_or_log(
-                "Incorrect numbers of aggregates in accummulable reduction rendering",
-                &format!(
-                    "full_aggrs={}, simple_aggrs={}, distinct_aggrs={}",
-                    full_aggrs.len(),
-                    simple_aggrs.len(),
-                    distinct_aggrs.len(),
-                ),
-            );
-        }
-
-        // Some of the aggregations may have the `distinct` bit set, which means that they'll
-        // need to be extracted from `collection` and be subjected to `distinct` with `key`.
-        // Other aggregations can be directly moved in to the `diff` field.
-        //
-        // In each case, the resulting collection should have `data` shaped as `(key, ())`
-        // and a `diff` that is a vector with length `3 * aggrs.len()`. The three values are
-        // generally the count, and then two aggregation-specific values. The size could be
-        // reduced if we want to specialize for the aggregations.
-
-        // Instantiate a default vector for diffs with the correct types at each
-        // position.
-        let zero_diffs: (Vec<_>, Diff) = (
-            full_aggrs
-                .iter()
-                .map(|f| accumulable_zero(&f.func))
-                .collect(),
-            0,
-        );
-
-        let mut to_aggregate = Vec::new();
-        if simple_aggrs.len() > 0 {
-            // First, collect all non-distinct aggregations in one pass.
-            let easy_cases = collection.explode_one({
-                let zero_diffs = zero_diffs.clone();
-                move |(key, row)| {
-                    let mut diffs = zero_diffs.clone();
-                    // Try to unpack only the datums we need. Unfortunately, since we
-                    // can't random access into a Row, we have to iterate through one by one.
-                    // TODO: Even though we don't have random access, we could still avoid unpacking
-                    // everything that we don't care about, and it might be worth it to extend the
-                    // Row API to do that.
-                    let mut row_iter = row.iter().enumerate();
-                    for (accumulable_index, datum_index, aggr) in simple_aggrs.iter() {
-                        let mut datum = row_iter.next().unwrap();
-                        while datum_index != &datum.0 {
-                            datum = row_iter.next().unwrap();
-                        }
-                        let datum = datum.1;
-                        diffs.0[*accumulable_index] = datum_to_accumulator(&aggr.func, datum);
-                        diffs.1 = 1;
-                    }
-                    ((key, ()), diffs)
-                }
-            });
-            to_aggregate.push(easy_cases);
-        }
-
-        // Next, collect all aggregations that require distinctness.
-        for (accumulable_index, datum_index, aggr) in distinct_aggrs.into_iter() {
-            let collection = collection
-                .map(move |(key, row)| {
-                    let binding = SharedRow::get();
-                    let mut row_builder = binding.borrow_mut();
-                    let value = row.iter().nth(datum_index).unwrap();
-                    row_builder.packer().push(value);
-                    (key, row_builder.clone())
-                })
-                .map(|k| (k, ()))
-                .mz_arrange::<KeySpine<(Row, Row), _, _>>(
-                    "Arranged Accumulable Distinct [val: empty]",
-                )
-                .mz_reduce_abelian::<_, KeySpine<_, _, _>>(
-                    "Reduced Accumulable Distinct [val: empty]",
-                    move |_k, _s, t| t.push(((), 1)),
-                )
-                .as_collection(|k, _| k.clone())
-                .explode_one({
-                    let zero_diffs = zero_diffs.clone();
-                    move |(key, row)| {
-                        let datum = row.iter().next().unwrap();
-                        let mut diffs = zero_diffs.clone();
-                        diffs.0[accumulable_index] = datum_to_accumulator(&aggr.func, datum);
-                        diffs.1 = 1;
-                        ((key, ()), diffs)
-                    }
-                });
-            to_aggregate.push(collection);
-        }
-
-        // now concatenate, if necessary, multiple aggregations
-        let collection = if to_aggregate.len() == 1 {
-            to_aggregate.remove(0)
-        } else {
-            differential_dataflow::collection::concatenate(&mut collection.scope(), to_aggregate)
-        };
-
-        // Allocations for the two closures.
-        let mut datums1 = DatumVec::new();
-        let mut datums2 = DatumVec::new();
-        let mfp_after1 = mfp_after.clone();
-        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
-        let full_aggrs2 = full_aggrs.clone();
-
-        let error_logger = self.error_logger();
-        let err_full_aggrs = full_aggrs.clone();
-        let (arranged_output, arranged_errs) = collection
-            .mz_arrange::<RowSpine<_, (Vec<Accum>, Diff)>>("ArrangeAccumulable [val: empty]")
-            .reduce_pair::<_, RowRowSpine<_, _>, _, RowErrSpine<_, _>>(
-                "ReduceAccumulable",
-                "AccumulableErrorCheck",
-                {
-                    move |key, input, output| {
-                        let (ref accums, total) = input[0].1;
-
-                        let temp_storage = RowArena::new();
-                        let datum_iter = key.into_datum_iter(None);
-                        let mut datums_local = datums1.borrow();
-                        datums_local.extend(datum_iter);
-                        let key_len = datums_local.len();
-                        for (aggr, accum) in full_aggrs.iter().zip(accums) {
-                            datums_local.push(finalize_accum(&aggr.func, accum, total));
-                        }
-
                         if let Some(row) = evaluate_mfp_after(
                             &mfp_after1,
                             &mut datums_local,
@@ -1445,65 +397,1085 @@ where
                             output.push((row, 1));
                         }
                     }
-                },
-                move |key, input, output| {
-                    let (ref accums, total) = input[0].1;
-                    for (aggr, accum) in err_full_aggrs.iter().zip(accums) {
-                        // We first test here if inputs without net-positive records are present,
-                        // producing an error to the logs and to the query output if that is the case.
-                        if total == 0 && !accum.is_zero() {
-                            error_logger.log(
-                                "Net-zero records with non-zero accumulation in ReduceAccumulable",
-                                &format!("aggr={aggr:?}, accum={accum:?}"),
-                            );
-                            let key = key.into_owned();
-                            let message = format!(
-                                "Invalid data in source, saw net-zero records for key {key} \
-                                 with non-zero accumulation in accumulable aggregate"
-                            );
-                            output.push((EvalError::Internal(message).into(), 1));
-                        }
-                        match (&aggr.func, &accum) {
-                            (AggregateFunc::SumUInt16, Accum::SimpleNumber { accum, .. })
-                            | (AggregateFunc::SumUInt32, Accum::SimpleNumber { accum, .. })
-                            | (AggregateFunc::SumUInt64, Accum::SimpleNumber { accum, .. }) => {
-                                if accum.is_negative() {
-                                    error_logger.log(
-                                    "Invalid negative unsigned aggregation in ReduceAccumulable",
-                                    &format!("aggr={aggr:?}, accum={accum:?}"),
-                                );
-                                    let key = key.into_owned();
-                                    let message = format!(
-                                        "Invalid data in source, saw negative accumulation with \
-                                         unsigned type for key {key}"
-                                    );
-                                    output.push((EvalError::Internal(message).into(), 1));
-                                }
-                            }
-                            _ => (), // no more errors to check for at this point!
-                        }
-                    }
+                }
+            },
+            move |key, input, output| {
+                if input.len() != n_distinct_aggregate_types {
+                    // We expected to stitch together exactly as many aggregate types as requested
+                    // by the collation. If we cannot, we log an error and produce no output for
+                    // this key.
+                    let message = "Mismatched aggregates for key in ReduceCollation";
+                    error_logger.log(
+                        message,
+                        &format!(
+                            "key={key:?}, n_aggregates_requested={requested}, \
+                                 n_distinct_aggregate_types={n_distinct_aggregate_types}",
+                            requested = input.len(),
+                        ),
+                    );
+                    output.push((EvalError::Internal(message.to_string()).into(), 1));
+                    return;
+                }
 
-                    // If `mfp_after` can error, then evaluate it here.
-                    let Some(mfp) = &mfp_after2 else { return };
+                let mut accumulable = DatumList::empty().iter();
+                let mut hierarchical = DatumList::empty().iter();
+                let mut basic = DatumList::empty().iter();
+                for (item, _) in input.iter() {
+                    let reduction_type = &item.0;
+                    let row = &item.1;
+                    match reduction_type {
+                        ReductionType::Accumulable => accumulable = row.iter(),
+                        ReductionType::Hierarchical => hierarchical = row.iter(),
+                        ReductionType::Basic => basic = row.iter(),
+                    }
+                }
+
+                let temp_storage = RowArena::new();
+                let datum_iter = key.into_datum_iter(None);
+                let mut datums_local = datums2.borrow();
+                datums_local.extend(datum_iter);
+
+                for typ in aggregate_types_err.iter() {
+                    let datum = match typ {
+                        ReductionType::Accumulable => accumulable.next(),
+                        ReductionType::Hierarchical => hierarchical.next(),
+                        ReductionType::Basic => basic.next(),
+                    };
+                    if let Some(datum) = datum {
+                        datums_local.push(datum);
+                    } else {
+                        // We cannot properly reconstruct a row if aggregates are missing.
+                        // This situation is not expected, so we log an error if it occurs.
+                        let message = "Missing value for key in ReduceCollation";
+                        error_logger.log(message, &format!("typ={typ:?}, key={key:?}"));
+                        output.push((EvalError::Internal(message.to_string()).into(), 1));
+                        return;
+                    }
+                }
+
+                // Note that we also do not want to have anything left over to stich.
+                // If we do, then we also have an error and would violate join semantics.
+                if (accumulable.next(), hierarchical.next(), basic.next()) != (None, None, None) {
+                    let message = "Rows too large for key in ReduceCollation";
+                    error_logger.log(message, &format!("key={key:?}"));
+                    output.push((EvalError::Internal(message.to_string()).into(), 1));
+                }
+
+                // Finally, if `mfp_after` can produce errors, then we should also report
+                // these here.
+                let Some(mfp) = &mfp_after2 else { return };
+                if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
+                    output.push((e.into(), 1));
+                }
+            },
+        );
+    (oks, errs.as_collection(|_, v| v.into_owned()))
+}
+
+fn dispatch_build_distinct<S>(
+    &self,
+    collection: Collection<S, (Row, Row), Diff>,
+    mfp_after: Option<SafeMfpPlan>,
+) -> (
+    SpecializedArrangement<S>,
+    Collection<S, DataflowError, Diff>,
+)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    if self.enable_specialized_arrangements {
+        let collection = collection.map(|(k, v)| {
+            assert!(v.is_empty());
+            (k, ())
+        });
+        let (arrangement, errs) = self.build_distinct::<RowSpine<_, _>, RowValSpine<_, _, _>, _>(
+            collection,
+            " [val: empty]",
+            mfp_after,
+        );
+        (SpecializedArrangement::RowUnit(arrangement), errs)
+    } else {
+        let collection = collection.inspect(|((_, v), _, _)| assert!(v.is_empty()));
+        let (arrangement, errs) = self
+            .build_distinct::<RowRowSpine<_, _>, RowValSpine<_, _, _>, _>(
+                collection, "", mfp_after,
+            );
+        (SpecializedArrangement::RowRow(arrangement), errs)
+    }
+}
+
+/// Build the dataflow to compute the set of distinct keys.
+fn build_distinct<T1, T2, S>(
+    &self,
+    collection: Collection<S, (Row, T1::ValOwned), Diff>,
+    tag: &str,
+    mfp_after: Option<SafeMfpPlan>,
+) -> (
+    Arranged<S, TraceAgent<T1>>,
+    Collection<S, DataflowError, Diff>,
+)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+    T1: Trace<KeyOwned = Row, Time = G::Timestamp, Diff = Diff> + 'static,
+    T1::Batch: Batch,
+    T1::Batcher: Batcher<Item = ((Row, T1::ValOwned), G::Timestamp, Diff)>,
+    for<'a> T1::Key<'a>: std::fmt::Debug + IntoRowByTypes,
+    T1::ValOwned: Columnation + ExchangeData + Default,
+    Arranged<S, TraceAgent<T1>>: ArrangementSize,
+    T2: for<'a> Trace<
+            Key<'a> = T1::Key<'a>,
+            KeyOwned = Row,
+            ValOwned = DataflowError,
+            Time = G::Timestamp,
+            Diff = Diff,
+        > + 'static,
+    T2::Batch: Batch,
+    T2::Batcher: Batcher<Item = ((Row, T2::ValOwned), G::Timestamp, Diff)>,
+    Arranged<S, TraceAgent<T2>>: ArrangementSize,
+{
+    let error_logger = self.error_logger();
+
+    let (input_name, output_name) = (
+        format!("Arranged DistinctBy{}", tag),
+        format!("DistinctBy{}", tag),
+    );
+
+    // Allocations for the two closures.
+    let mut datums1 = DatumVec::new();
+    let mut datums2 = DatumVec::new();
+    let mfp_after1 = mfp_after.clone();
+    let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
+
+    let (output, errors) = collection
+        .mz_arrange::<T1>(&input_name)
+        .reduce_pair::<_, T1, _, T2>(
+            &output_name,
+            "DistinctByErrorCheck",
+            move |key, _input, output| {
+                let temp_storage = RowArena::new();
+                let mut datums_local = datums1.borrow();
+                datums_local.extend(key.into_datum_iter(None));
+
+                // Note that the key contains all the columns in a `Distinct` and that `mfp_after` is
+                // required to preserve the key. Therefore, if `mfp_after` maps, then it must project
+                // back to the key. As a consequence, we can treat `mfp_after` as a filter here.
+                if mfp_after1
+                    .as_ref()
+                    .map(|mfp| mfp.evaluate_inner(&mut datums_local, &temp_storage))
+                    .unwrap_or(Ok(true))
+                    == Ok(true)
+                {
+                    // We're pushing a unit value here because the key is implicitly added by the
+                    // arrangement, and the permutation logic takes care of using the key part of the
+                    // output.
+                    output.push((T1::ValOwned::default(), 1));
+                }
+            },
+            move |key, input: &[(_, Diff)], output| {
+                for (_, count) in input.iter() {
+                    if count.is_positive() {
+                        continue;
+                    }
+                    let message = "Non-positive multiplicity in DistinctBy";
+                    error_logger.log(message, &format!("row={key:?}, count={count}"));
+                    output.push((EvalError::Internal(message.to_string()).into(), 1));
+                    return;
+                }
+                // If `mfp_after` can error, then evaluate it here.
+                let Some(mfp) = &mfp_after2 else { return };
+                let temp_storage = RowArena::new();
+                let datum_iter = key.into_datum_iter(None);
+                let mut datums_local = datums2.borrow();
+                datums_local.extend(datum_iter);
+
+                if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
+                    output.push((e.into(), 1));
+                }
+            },
+        );
+    (output, errors.as_collection(|_k, v| v.into_owned()))
+}
+
+/// Build the dataflow to compute and arrange multiple non-accumulable,
+/// non-hierarchical aggregations on `input`.
+///
+/// This function assumes that we are explicitly rendering multiple basic aggregations.
+/// For each aggregate, we render a different reduce operator, and then fuse
+/// results together into a final arrangement that presents all the results
+/// in the order specified by `aggrs`.
+fn build_basic_aggregates<S>(
+    &self,
+    input: Collection<S, (Row, Row), Diff>,
+    aggrs: Vec<(usize, AggregateExpr)>,
+    mfp_after: Option<SafeMfpPlan>,
+) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    // We are only using this function to render multiple basic aggregates and
+    // stitch them together. If that's not true we should complain.
+    if aggrs.len() <= 1 {
+        self.error_logger().soft_panic_or_log(
+            "Too few aggregations when building basic aggregates",
+            &format!("len={}", aggrs.len()),
+        )
+    }
+    let mut err_output = None;
+    let mut to_collect = Vec::new();
+    for (index, aggr) in aggrs {
+        let (result, errs) =
+            self.build_basic_aggregate(input.clone(), index, &aggr, err_output.is_none(), None);
+        if errs.is_some() {
+            err_output = errs
+        }
+        to_collect.push(
+            result.as_collection(move |key, val| (key.into_owned(), (index, val.into_owned()))),
+        );
+    }
+
+    // Allocations for the two closures.
+    let mut datums1 = DatumVec::new();
+    let mut datums2 = DatumVec::new();
+    let mfp_after1 = mfp_after.clone();
+    let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
+
+    let arranged = differential_dataflow::collection::concatenate(&mut input.scope(), to_collect)
+        .mz_arrange::<RowValSpine<_, _, _>>("Arranged ReduceFuseBasic input");
+
+    let output = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceFuseBasic", {
+        move |key, input, output| {
+            let temp_storage = RowArena::new();
+            let datum_iter = key.into_datum_iter(None);
+            let mut datums_local = datums1.borrow();
+            datums_local.extend(datum_iter);
+            let key_len = datums_local.len();
+
+            for ((_, row), _) in input.iter() {
+                datums_local.push(row.unpack_first());
+            }
+
+            if let Some(row) =
+                evaluate_mfp_after(&mfp_after1, &mut datums_local, &temp_storage, key_len)
+            {
+                output.push((row, 1));
+            }
+        }
+    });
+    // If `mfp_after` can error, then we need to render a paired reduction
+    // to scan for these potential errors. Note that we cannot directly use
+    // `mz_timely_util::reduce::ReduceExt::reduce_pair` here because we only
+    // conditionally render the second component of the reduction pair.
+    let validation_errs = err_output.expect("expected to validate in at least one aggregate");
+    if let Some(mfp) = mfp_after2 {
+        let mfp_errs = arranged
+            .mz_reduce_abelian::<_, RowErrSpine<_, _>>(
+                "ReduceFuseBasic Error Check",
+                move |key, input, output| {
+                    // Since negative accumulations are checked in at least one component
+                    // aggregate, we only need to look for MFP errors here.
                     let temp_storage = RowArena::new();
                     let datum_iter = key.into_datum_iter(None);
                     let mut datums_local = datums2.borrow();
                     datums_local.extend(datum_iter);
-                    for (aggr, accum) in full_aggrs2.iter().zip(accums) {
-                        datums_local.push(finalize_accum(&aggr.func, accum, total));
+
+                    for ((_, row), _) in input.iter() {
+                        datums_local.push(row.unpack_first());
                     }
 
                     if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
                         output.push((e.into(), 1));
                     }
                 },
-            );
-        (
-            arranged_output,
-            arranged_errs.as_collection(|_key, error| error.into_owned()),
-        )
+            )
+            .as_collection(|_, v| v.into_owned());
+        (output, validation_errs.concat(&mfp_errs))
+    } else {
+        (output, validation_errs)
     }
+}
+
+/// Build the dataflow to compute a single basic aggregation.
+///
+/// This method also applies distinctness if required.
+fn build_basic_aggregate<S>(
+    &self,
+    input: Collection<S, (Row, Row), Diff>,
+    index: usize,
+    aggr: &AggregateExpr,
+    validating: bool,
+    mfp_after: Option<SafeMfpPlan>,
+) -> (
+    RowRowArrangement<S>,
+    Option<Collection<S, DataflowError, Diff>>,
+)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    let AggregateExpr {
+        func,
+        expr: _,
+        distinct,
+    } = aggr.clone();
+
+    // Extract the value we were asked to aggregate over.
+    let mut partial = input.map(move |(key, row)| {
+        let binding = SharedRow::get();
+        let mut row_builder = binding.borrow_mut();
+        let value = row.iter().nth(index).unwrap();
+        row_builder.packer().push(value);
+        (key, row_builder.clone())
+    });
+
+    let mut err_output = None;
+
+    // If `distinct` is set, we restrict ourselves to the distinct `(key, val)`.
+    if distinct {
+        if validating {
+            let (oks, errs) = self
+                .build_reduce_inaccumulable_distinct::<_, KeyValSpine<_, Result<(), String>, _, _>>(
+                    partial, None,
+                )
+                .as_collection(|k, v| (k.into_owned(), v.into_owned()))
+                .map_fallible("Demux Errors", move |(key, result)| match result {
+                    Ok(()) => Ok(key),
+                    Err(m) => Err(EvalError::Internal(m).into()),
+                });
+            err_output = Some(errs);
+            partial = oks;
+        } else {
+            partial = self
+                .build_reduce_inaccumulable_distinct::<_, KeySpine<_, _, _>>(
+                    partial,
+                    Some(" [val: empty]"),
+                )
+                .as_collection(|k, _| k.into_owned());
+        }
+    }
+
+    // Allocations for the two closures.
+    let mut datums1 = DatumVec::new();
+    let mut datums2 = DatumVec::new();
+    let mfp_after1 = mfp_after.clone();
+    let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
+    let func2 = func.clone();
+
+    let arranged = partial.mz_arrange::<RowRowSpine<_, _>>("Arranged ReduceInaccumulable");
+    let oks = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceInaccumulable", {
+        move |key, source, target| {
+            // We respect the multiplicity here (unlike in hierarchical aggregation)
+            // because we don't know that the aggregation method is not sensitive
+            // to the number of records.
+            let iter = source.iter().flat_map(|(v, w)| {
+                // Note that in the non-positive case, this is wrong, but harmless because
+                // our other reduction will produce an error.
+                let count = usize::try_from(*w).unwrap_or(0);
+                std::iter::repeat(v.into_datum_iter(None).next().unwrap()).take(count)
+            });
+
+            let temp_storage = RowArena::new();
+            let datum_iter = key.into_datum_iter(None);
+            let mut datums_local = datums1.borrow();
+            datums_local.extend(datum_iter);
+            let key_len = datums_local.len();
+            datums_local.push(
+                // Note that this is not necessarily a window aggregation, in which case
+                // `eval_fast_window_agg` delegates to the normal `eval`.
+                func.eval_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
+                    iter,
+                    &temp_storage,
+                ),
+            );
+
+            if let Some(row) =
+                evaluate_mfp_after(&mfp_after1, &mut datums_local, &temp_storage, key_len)
+            {
+                target.push((row, 1));
+            }
+        }
+    });
+
+    // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here, but
+    // we then wouldn't be able to do this error check conditionally.  See its documentation for the
+    // rationale around using a second reduction here.
+    let must_validate = validating && err_output.is_none();
+    if must_validate || mfp_after2.is_some() {
+        let error_logger = self.error_logger();
+
+        let errs = arranged
+            .mz_reduce_abelian::<_, RowErrSpine<_, _>>(
+                "ReduceInaccumulable Error Check",
+                move |key, source, target| {
+                    // Negative counts would be surprising, but until we are 100% certain we won't
+                    // see them, we should report when we do. We may want to bake even more info
+                    // in here in the future.
+                    if must_validate {
+                        for (value, count) in source.iter() {
+                            if count.is_positive() {
+                                continue;
+                            }
+                            let value = value.into_owned();
+                            let message = "Non-positive accumulation in ReduceInaccumulable";
+                            error_logger.log(message, &format!("value={value:?}, count={count}"));
+                            target.push((EvalError::Internal(message.to_string()).into(), 1));
+                            return;
+                        }
+                    }
+
+                    // We know that `mfp_after` can error if it exists, so try to evaluate it here.
+                    let Some(mfp) = &mfp_after2 else { return };
+                    let iter = source.iter().flat_map(|(mut v, w)| {
+                        let count = usize::try_from(*w).unwrap_or(0);
+                        // This would ideally use `into_datum_iter` but we cannot as it needs to
+                        // borrow `v` and only presents datums with that lifetime, not any longer.
+                        std::iter::repeat(v.next().unwrap()).take(count)
+                    });
+
+                    let temp_storage = RowArena::new();
+                    let datum_iter = key.into_datum_iter(None);
+                    let mut datums_local = datums2.borrow();
+                    datums_local.extend(datum_iter);
+                    datums_local.push(
+                        func2.eval_fast_window_agg::<_, window_agg_helpers::OneByOneAggrImpls>(
+                            iter,
+                            &temp_storage,
+                        ),
+                    );
+                    if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
+                        target.push((e.into(), 1));
+                    }
+                },
+            )
+            .as_collection(|_, v| v.into_owned());
+        if let Some(e) = err_output {
+            err_output = Some(e.concat(&errs));
+        } else {
+            err_output = Some(errs);
+        }
+    }
+    (oks, err_output)
+}
+
+fn build_reduce_inaccumulable_distinct<S, Tr>(
+    &self,
+    input: Collection<S, (Row, Row), Diff>,
+    name_tag: Option<&str>,
+) -> Arranged<S, TraceAgent<Tr>>
+where
+    S: Scope<Timestamp = G::Timestamp>,
+    Tr::ValOwned: MaybeValidatingRow<(), String>,
+    Tr: Trace
+        + for<'a> TraceReader<
+            Key<'a> = &'a (Row, Row),
+            KeyOwned = (Row, Row),
+            Time = G::Timestamp,
+            Diff = Diff,
+        > + 'static,
+    Tr::Batch: Batch,
+    Tr::Batcher: Batcher<Item = (((Row, Row), Tr::ValOwned), G::Timestamp, Diff)>,
+    Arranged<S, TraceAgent<Tr>>: ArrangementSize,
+{
+    let error_logger = self.error_logger();
+
+    let output_name = format!(
+        "ReduceInaccumulable Distinct{}",
+        name_tag.unwrap_or_default()
+    );
+
+    let input: KeyCollection<_, _, _> = input.into();
+    input
+        .mz_arrange::<KeySpine<(Row, Row), _, _>>(
+            "Arranged ReduceInaccumulable Distinct [val: empty]",
+        )
+        .mz_reduce_abelian::<_, Tr>(&output_name, move |_, source, t| {
+            if let Some(err) = Tr::ValOwned::into_error() {
+                for (value, count) in source.iter() {
+                    if count.is_positive() {
+                        continue;
+                    }
+
+                    let message = "Non-positive accumulation in ReduceInaccumulable DISTINCT";
+                    error_logger.log(message, &format!("value={value:?}, count={count}"));
+                    t.push((err(message.to_string()), 1));
+                    return;
+                }
+            }
+            t.push((Tr::ValOwned::ok(()), 1))
+        })
+}
+
+/// Build the dataflow to compute and arrange multiple hierarchical aggregations
+/// on non-monotonic inputs.
+///
+/// This function renders a single reduction tree that computes aggregations with
+/// a priority queue implemented with a series of reduce operators that partition
+/// the input into buckets, and compute the aggregation over very small buckets
+/// and feed the results up to larger buckets.
+///
+/// Note that this implementation currently ignores the distinct bit because we
+/// currently only perform min / max hierarchically and the reduction tree
+/// efficiently suppresses non-distinct updates.
+fn build_bucketed<S>(
+    &self,
+    input: Collection<S, (Row, Row), Diff>,
+    BucketedPlan {
+        aggr_funcs,
+        skips,
+        buckets,
+    }: BucketedPlan,
+    mfp_after: Option<SafeMfpPlan>,
+) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    let mut err_output: Option<Collection<S, _, _>> = None;
+    let arranged_output = input.scope().region_named("ReduceHierarchical", |inner| {
+        let input = input.enter(inner);
+
+        // Gather the relevant values into a vec of rows ordered by aggregation_index
+        let input = input.map(move |(key, row)| {
+            let binding = SharedRow::get();
+            let mut row_builder = binding.borrow_mut();
+            let mut values = Vec::with_capacity(skips.len());
+            let mut row_iter = row.iter();
+            for skip in skips.iter() {
+                row_builder.packer().push(row_iter.nth(*skip).unwrap());
+                values.push(row_builder.clone());
+            }
+
+            (key, values)
+        });
+
+        // Repeatedly apply hierarchical reduction with a progressively coarser key.
+        let mut stage = input.map(move |(key, values)| ((key, values.hashed()), values));
+        for b in buckets.into_iter() {
+            let input = stage.map(move |((key, hash), values)| ((key, hash % b), values));
+
+            // We only want the first stage to perform validation of whether invalid accumulations
+            // were observed in the input. Subsequently, we will either produce an error in the error
+            // stream or produce correct data in the output stream.
+            let negated_output = if err_output.is_none() {
+                let (oks, errs) = self
+                    .build_bucketed_negated_output::<_, Result<Vec<Row>, (Row, u64)>>(
+                        &input,
+                        aggr_funcs.clone(),
+                    )
+                    .map_fallible(
+                        "Checked Invalid Accumulations",
+                        |(key, result)| match result {
+                            Err((key, _)) => {
+                                let message = format!(
+                                    "Invalid data in source, saw non-positive accumulation \
+                                         for key {key:?} in hierarchical mins-maxes aggregate"
+                                );
+                                Err(EvalError::Internal(message).into())
+                            }
+                            Ok(values) => Ok((key, values)),
+                        },
+                    );
+                err_output = Some(errs.leave_region());
+                oks
+            } else {
+                self.build_bucketed_negated_output::<_, Vec<Row>>(&input, aggr_funcs.clone())
+            };
+
+            stage = negated_output
+                .negate()
+                .concat(&input)
+                .consolidate_named::<KeySpine<_, _, _>>("Consolidated MinsMaxesHierarchical");
+        }
+
+        // Discard the hash from the key and return to the format of the input data.
+        let partial = stage.map(|((key, _hash), values)| (key, values));
+
+        // Allocations for the two closures.
+        let mut datums1 = DatumVec::new();
+        let mut datums2 = DatumVec::new();
+        let mfp_after1 = mfp_after.clone();
+        let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
+        let aggr_funcs2 = aggr_funcs.clone();
+
+        // Build a series of stages for the reduction
+        // Arrange the final result into (key, Row)
+        let error_logger = self.error_logger();
+        // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
+        // view mz_internal.mz_expected_group_size_advice.
+        let arranged = partial.mz_arrange::<RowValSpine<Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
+        // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
+        // but we then wouldn't be able to do this error check conditionally.  See its documentation
+        // for the rationale around using a second reduction here.
+        let must_validate = err_output.is_none();
+        if must_validate || mfp_after2.is_some() {
+            let errs = arranged
+                .mz_reduce_abelian::<_, RowErrSpine<_, _>>(
+                    "ReduceMinsMaxes Error Check",
+                    move |key, source, target| {
+                        // Negative counts would be surprising, but until we are 100% certain we wont
+                        // see them, we should report when we do. We may want to bake even more info
+                        // in here in the future.
+                        if must_validate {
+                            for (val, count) in source.iter() {
+                                if count.is_positive() {
+                                    continue;
+                                }
+                                let val = val.into_owned();
+                                let message = "Non-positive accumulation in ReduceMinsMaxes";
+                                error_logger.log(message, &format!("val={val:?}, count={count}"));
+                                target.push((EvalError::Internal(message.to_string()).into(), 1));
+                                return;
+                            }
+                        }
+
+                        // We know that `mfp_after` can error if it exists, so try to evaluate it here.
+                        let Some(mfp) = &mfp_after2 else { return };
+                        let temp_storage = RowArena::new();
+                        let datum_iter = key.into_datum_iter(None);
+                        let mut datums_local = datums2.borrow();
+                        datums_local.extend(datum_iter);
+                        for (aggr_index, func) in aggr_funcs2.iter().enumerate() {
+                            let iter = source
+                                .iter()
+                                .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
+                            datums_local.push(func.eval(iter, &temp_storage));
+                        }
+                        if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage)
+                        {
+                            target.push((e.into(), 1));
+                        }
+                    },
+                )
+                .as_collection(|_, v| v.into_owned())
+                .leave_region();
+            if let Some(e) = &err_output {
+                err_output = Some(e.concat(&errs));
+            } else {
+                err_output = Some(errs);
+            }
+        }
+        arranged
+            .mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMinsMaxes", {
+                move |key, source, target| {
+                    let temp_storage = RowArena::new();
+                    let datum_iter = key.into_datum_iter(None);
+                    let mut datums_local = datums1.borrow();
+                    datums_local.extend(datum_iter);
+                    let key_len = datums_local.len();
+                    for (aggr_index, func) in aggr_funcs.iter().enumerate() {
+                        let iter = source
+                            .iter()
+                            .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
+                        datums_local.push(func.eval(iter, &temp_storage));
+                    }
+
+                    if let Some(row) =
+                        evaluate_mfp_after(&mfp_after1, &mut datums_local, &temp_storage, key_len)
+                    {
+                        target.push((row, 1));
+                    }
+                }
+            })
+            .leave_region()
+    });
+    (
+        arranged_output,
+        err_output.expect("expected to validate in one level of the hierarchy"),
+    )
+}
+
+/// Build the dataflow for one stage of a reduction tree for multiple hierarchical
+/// aggregates.
+///
+/// `buckets` indicates the number of buckets in this stage. We do some non
+/// obvious trickery here to limit the memory usage per layer by internally
+/// holding only the elements that were rejected by this stage. However, the
+/// output collection maintains the `((key, bucket), (passing value)` for this
+/// stage.
+/// `validating` indicates whether we want this stage to perform error detection
+/// for invalid accumulations. Once a stage is clean of such errors, subsequent
+/// stages can skip validation.
+fn build_bucketed_negated_output<S, R>(
+    &self,
+    input: &Collection<S, ((Row, u64), Vec<Row>), Diff>,
+    aggrs: Vec<AggregateFunc>,
+) -> Collection<S, ((Row, u64), R), Diff>
+where
+    S: Scope<Timestamp = G::Timestamp>,
+    R: MaybeValidatingRow<Vec<Row>, (Row, u64)>,
+{
+    let error_logger = self.error_logger();
+    // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
+    // view mz_internal.mz_expected_group_size_advice.
+    let arranged_input =
+        input.mz_arrange::<KeyValSpine<_, Vec<Row>, _, _>>("Arranged MinsMaxesHierarchical input");
+
+    arranged_input
+        .mz_reduce_abelian::<_, KeyValSpine<_, _, _, _>>(
+            "Reduced Fallibly MinsMaxesHierarchical",
+            move |key, source, target| {
+                if let Some(err) = R::into_error() {
+                    // Should negative accumulations reach us, we should loudly complain.
+                    for (value, count) in source.iter() {
+                        if count.is_positive() {
+                            continue;
+                        }
+                        error_logger.log(
+                            "Non-positive accumulation in MinsMaxesHierarchical",
+                            &format!("key={key:?}, value={value:?}, count={count}"),
+                        );
+                        // After complaining, output an error here so that we can eventually
+                        // report it in an error stream.
+                        target.push((err(key.clone()), -1));
+                        return;
+                    }
+                }
+                let binding = SharedRow::get();
+                let mut row_builder = binding.borrow_mut();
+                let mut output = Vec::with_capacity(aggrs.len());
+                for (aggr_index, func) in aggrs.iter().enumerate() {
+                    let iter = source
+                        .iter()
+                        .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
+                    row_builder.packer().push(func.eval(iter, &RowArena::new()));
+                    output.push(row_builder.clone());
+                }
+                // We only want to arrange the parts of the input that are not part of the output.
+                // More specifically, we want to arrange it so that `input.concat(&output.negate())`
+                // gives us the intended value of this aggregate function. Also we assume that regardless
+                // of the multiplicity of the final result in the input, we only want to have one copy
+                // in the output.
+                target.push((R::ok(output), -1));
+                target.extend(
+                    source
+                        .iter()
+                        .map(|(values, cnt)| (R::ok((*values).clone()), *cnt)),
+                );
+            },
+        )
+        .as_collection(|k, v| (k.clone(), v.clone()))
+}
+
+/// Build the dataflow to compute and arrange multiple hierarchical aggregations
+/// on monotonic inputs.
+fn build_monotonic<S>(
+    &self,
+    collection: Collection<S, (Row, Row), Diff>,
+    MonotonicPlan {
+        aggr_funcs,
+        skips,
+        must_consolidate,
+    }: MonotonicPlan,
+    mfp_after: Option<SafeMfpPlan>,
+) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    // Gather the relevant values into a vec of rows ordered by aggregation_index
+    let collection = collection
+        .map(move |(key, row)| {
+            let binding = SharedRow::get();
+            let mut row_builder = binding.borrow_mut();
+            let mut values = Vec::with_capacity(skips.len());
+            let mut row_iter = row.iter();
+            for skip in skips.iter() {
+                row_builder.packer().push(row_iter.nth(*skip).unwrap());
+                values.push(row_builder.clone());
+            }
+
+            (key, values)
+        })
+        .consolidate_named_if::<KeySpine<_, _, _>>(
+            must_consolidate,
+            "Consolidated ReduceMonotonic input",
+        );
+
+    // It should be now possible to ensure that we have a monotonic collection.
+    let error_logger = self.error_logger();
+    let (partial, validation_errs) = collection.ensure_monotonic(move |data, diff| {
+        error_logger.log(
+            "Non-monotonic input to ReduceMonotonic",
+            &format!("data={data:?}, diff={diff}"),
+        );
+        let m = "tried to build a monotonic reduction on non-monotonic input".to_string();
+        (EvalError::Internal(m).into(), 1)
+    });
+    // We can place our rows directly into the diff field, and
+    // only keep the relevant one corresponding to evaluating our
+    // aggregate, instead of having to do a hierarchical reduction.
+    let partial =
+        partial.explode_one(move |(key, values)| {
+            let mut output = Vec::new();
+            for (row, func) in values.into_iter().zip(aggr_funcs.iter()) {
+                output.push(monoids::get_monoid(row, func).expect(
+                    "hierarchical aggregations are expected to have monoid implementations",
+                ));
+            }
+            (key, output)
+        });
+
+    // Allocations for the two closures.
+    let mut datums1 = DatumVec::new();
+    let mut datums2 = DatumVec::new();
+    let mfp_after1 = mfp_after.clone();
+    let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
+
+    let partial: KeyCollection<_, _, _> = partial.into();
+    let arranged =
+        partial.mz_arrange::<RowSpine<_, Vec<ReductionMonoid>>>("ArrangeMonotonic [val: empty]");
+    let output = arranged.mz_reduce_abelian::<_, RowRowSpine<_, _>>("ReduceMonotonic", {
+        move |key, input, output| {
+            let temp_storage = RowArena::new();
+            let datum_iter = key.into_datum_iter(None);
+            let mut datums_local = datums1.borrow();
+            datums_local.extend(datum_iter);
+            let key_len = datums_local.len();
+            let accum = &input[0].1;
+            for monoid in accum.iter() {
+                datums_local.extend(monoid.finalize().iter());
+            }
+
+            if let Some(row) =
+                evaluate_mfp_after(&mfp_after1, &mut datums_local, &temp_storage, key_len)
+            {
+                output.push((row, 1));
+            }
+        }
+    });
+
+    // If `mfp_after` can error, then we need to render a paired reduction
+    // to scan for these potential errors. Note that we cannot directly use
+    // `mz_timely_util::reduce::ReduceExt::reduce_pair` here because we only
+    // conditionally render the second component of the reduction pair.
+    if let Some(mfp) = mfp_after2 {
+        let mfp_errs = arranged
+            .mz_reduce_abelian::<_, RowErrSpine<_, _>>("ReduceMonotonic Error Check", {
+                move |key, input, output| {
+                    let temp_storage = RowArena::new();
+                    let datum_iter = key.into_datum_iter(None);
+                    let mut datums_local = datums2.borrow();
+                    datums_local.extend(datum_iter);
+                    let accum = &input[0].1;
+                    for monoid in accum.iter() {
+                        datums_local.extend(monoid.finalize().iter());
+                    }
+                    if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
+                        output.push((e.into(), 1));
+                    }
+                }
+            })
+            .as_collection(|_k, v| v.clone());
+        (output, validation_errs.concat(&mfp_errs))
+    } else {
+        (output, validation_errs)
+    }
+}
+
+/// Build the dataflow to compute and arrange multiple accumulable aggregations.
+///
+/// The incoming values are moved to the update's "difference" field, at which point
+/// they can be accumulated in place. The `count` operator promotes the accumulated
+/// values to data, at which point a final map applies operator-specific logic to
+/// yield the final aggregate.
+fn build_accumulable<S>(
+    &self,
+    collection: Collection<S, (Row, Row), Diff>,
+    AccumulablePlan {
+        full_aggrs,
+        simple_aggrs,
+        distinct_aggrs,
+    }: AccumulablePlan,
+    mfp_after: Option<SafeMfpPlan>,
+) -> (RowRowArrangement<S>, Collection<S, DataflowError, Diff>)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    // we must have called this function with something to reduce
+    if full_aggrs.len() == 0 || simple_aggrs.len() + distinct_aggrs.len() != full_aggrs.len() {
+        self.error_logger().soft_panic_or_log(
+            "Incorrect numbers of aggregates in accummulable reduction rendering",
+            &format!(
+                "full_aggrs={}, simple_aggrs={}, distinct_aggrs={}",
+                full_aggrs.len(),
+                simple_aggrs.len(),
+                distinct_aggrs.len(),
+            ),
+        );
+    }
+
+    // Some of the aggregations may have the `distinct` bit set, which means that they'll
+    // need to be extracted from `collection` and be subjected to `distinct` with `key`.
+    // Other aggregations can be directly moved in to the `diff` field.
+    //
+    // In each case, the resulting collection should have `data` shaped as `(key, ())`
+    // and a `diff` that is a vector with length `3 * aggrs.len()`. The three values are
+    // generally the count, and then two aggregation-specific values. The size could be
+    // reduced if we want to specialize for the aggregations.
+
+    // Instantiate a default vector for diffs with the correct types at each
+    // position.
+    let zero_diffs: (Vec<_>, Diff) = (
+        full_aggrs
+            .iter()
+            .map(|f| accumulable_zero(&f.func))
+            .collect(),
+        0,
+    );
+
+    let mut to_aggregate = Vec::new();
+    if simple_aggrs.len() > 0 {
+        // First, collect all non-distinct aggregations in one pass.
+        let easy_cases = collection.explode_one({
+            let zero_diffs = zero_diffs.clone();
+            move |(key, row)| {
+                let mut diffs = zero_diffs.clone();
+                // Try to unpack only the datums we need. Unfortunately, since we
+                // can't random access into a Row, we have to iterate through one by one.
+                // TODO: Even though we don't have random access, we could still avoid unpacking
+                // everything that we don't care about, and it might be worth it to extend the
+                // Row API to do that.
+                let mut row_iter = row.iter().enumerate();
+                for (accumulable_index, datum_index, aggr) in simple_aggrs.iter() {
+                    let mut datum = row_iter.next().unwrap();
+                    while datum_index != &datum.0 {
+                        datum = row_iter.next().unwrap();
+                    }
+                    let datum = datum.1;
+                    diffs.0[*accumulable_index] = datum_to_accumulator(&aggr.func, datum);
+                    diffs.1 = 1;
+                }
+                ((key, ()), diffs)
+            }
+        });
+        to_aggregate.push(easy_cases);
+    }
+
+    // Next, collect all aggregations that require distinctness.
+    for (accumulable_index, datum_index, aggr) in distinct_aggrs.into_iter() {
+        let collection = collection
+            .map(move |(key, row)| {
+                let binding = SharedRow::get();
+                let mut row_builder = binding.borrow_mut();
+                let value = row.iter().nth(datum_index).unwrap();
+                row_builder.packer().push(value);
+                (key, row_builder.clone())
+            })
+            .map(|k| (k, ()))
+            .mz_arrange::<KeySpine<(Row, Row), _, _>>("Arranged Accumulable Distinct [val: empty]")
+            .mz_reduce_abelian::<_, KeySpine<_, _, _>>(
+                "Reduced Accumulable Distinct [val: empty]",
+                move |_k, _s, t| t.push(((), 1)),
+            )
+            .as_collection(|k, _| k.clone())
+            .explode_one({
+                let zero_diffs = zero_diffs.clone();
+                move |(key, row)| {
+                    let datum = row.iter().next().unwrap();
+                    let mut diffs = zero_diffs.clone();
+                    diffs.0[accumulable_index] = datum_to_accumulator(&aggr.func, datum);
+                    diffs.1 = 1;
+                    ((key, ()), diffs)
+                }
+            });
+        to_aggregate.push(collection);
+    }
+
+    // now concatenate, if necessary, multiple aggregations
+    let collection = if to_aggregate.len() == 1 {
+        to_aggregate.remove(0)
+    } else {
+        differential_dataflow::collection::concatenate(&mut collection.scope(), to_aggregate)
+    };
+
+    // Allocations for the two closures.
+    let mut datums1 = DatumVec::new();
+    let mut datums2 = DatumVec::new();
+    let mfp_after1 = mfp_after.clone();
+    let mfp_after2 = mfp_after.filter(|mfp| mfp.could_error());
+    let full_aggrs2 = full_aggrs.clone();
+
+    let error_logger = self.error_logger();
+    let err_full_aggrs = full_aggrs.clone();
+    let (arranged_output, arranged_errs) = collection
+        .mz_arrange::<RowSpine<_, (Vec<Accum>, Diff)>>("ArrangeAccumulable [val: empty]")
+        .reduce_pair::<_, RowRowSpine<_, _>, _, RowErrSpine<_, _>>(
+            "ReduceAccumulable",
+            "AccumulableErrorCheck",
+            {
+                move |key, input, output| {
+                    let (ref accums, total) = input[0].1;
+
+                    let temp_storage = RowArena::new();
+                    let datum_iter = key.into_datum_iter(None);
+                    let mut datums_local = datums1.borrow();
+                    datums_local.extend(datum_iter);
+                    let key_len = datums_local.len();
+                    for (aggr, accum) in full_aggrs.iter().zip(accums) {
+                        datums_local.push(finalize_accum(&aggr.func, accum, total));
+                    }
+
+                    if let Some(row) =
+                        evaluate_mfp_after(&mfp_after1, &mut datums_local, &temp_storage, key_len)
+                    {
+                        output.push((row, 1));
+                    }
+                }
+            },
+            move |key, input, output| {
+                let (ref accums, total) = input[0].1;
+                for (aggr, accum) in err_full_aggrs.iter().zip(accums) {
+                    // We first test here if inputs without net-positive records are present,
+                    // producing an error to the logs and to the query output if that is the case.
+                    if total == 0 && !accum.is_zero() {
+                        error_logger.log(
+                            "Net-zero records with non-zero accumulation in ReduceAccumulable",
+                            &format!("aggr={aggr:?}, accum={accum:?}"),
+                        );
+                        let key = key.into_owned();
+                        let message = format!(
+                            "Invalid data in source, saw net-zero records for key {key} \
+                                 with non-zero accumulation in accumulable aggregate"
+                        );
+                        output.push((EvalError::Internal(message).into(), 1));
+                    }
+                    match (&aggr.func, &accum) {
+                        (AggregateFunc::SumUInt16, Accum::SimpleNumber { accum, .. })
+                        | (AggregateFunc::SumUInt32, Accum::SimpleNumber { accum, .. })
+                        | (AggregateFunc::SumUInt64, Accum::SimpleNumber { accum, .. }) => {
+                            if accum.is_negative() {
+                                error_logger.log(
+                                    "Invalid negative unsigned aggregation in ReduceAccumulable",
+                                    &format!("aggr={aggr:?}, accum={accum:?}"),
+                                );
+                                let key = key.into_owned();
+                                let message = format!(
+                                    "Invalid data in source, saw negative accumulation with \
+                                         unsigned type for key {key}"
+                                );
+                                output.push((EvalError::Internal(message).into(), 1));
+                            }
+                        }
+                        _ => (), // no more errors to check for at this point!
+                    }
+                }
+
+                // If `mfp_after` can error, then evaluate it here.
+                let Some(mfp) = &mfp_after2 else { return };
+                let temp_storage = RowArena::new();
+                let datum_iter = key.into_datum_iter(None);
+                let mut datums_local = datums2.borrow();
+                datums_local.extend(datum_iter);
+                for (aggr, accum) in full_aggrs2.iter().zip(accums) {
+                    datums_local.push(finalize_accum(&aggr.func, accum, total));
+                }
+
+                if let Result::Err(e) = mfp.evaluate_inner(&mut datums_local, &temp_storage) {
+                    output.push((e.into(), 1));
+                }
+            },
+        );
+    (
+        arranged_output,
+        arranged_errs.as_collection(|_key, error| error.into_owned()),
+    )
+}
 }
 
 /// Evaluates the fused MFP, if one exists, on a reconstructed `DatumVecBorrow`

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -37,111 +37,111 @@ where
     G: Scope<Timestamp = mz_repr::Timestamp>,
     T: RenderTimestamp,
 {
-    /// Export the sink described by `sink` from the rendering context.
-    pub(crate) fn export_sink(
-        &mut self,
-        compute_state: &mut crate::compute_state::ComputeState,
-        tokens: &BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
-        dependency_ids: BTreeSet<GlobalId>,
-        sink_id: GlobalId,
-        sink: &ComputeSinkDesc<CollectionMetadata>,
-    ) {
-        soft_assert_or_log!(
-            sink.non_null_assertions.is_strictly_sorted(),
-            "non-null assertions not sorted"
-        );
+/// Export the sink described by `sink` from the rendering context.
+pub(crate) fn export_sink(
+    &mut self,
+    compute_state: &mut crate::compute_state::ComputeState,
+    tokens: &BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
+    dependency_ids: BTreeSet<GlobalId>,
+    sink_id: GlobalId,
+    sink: &ComputeSinkDesc<CollectionMetadata>,
+) {
+    soft_assert_or_log!(
+        sink.non_null_assertions.is_strictly_sorted(),
+        "non-null assertions not sorted"
+    );
 
-        // put together tokens that belong to the export
-        let mut needed_tokens = Vec::new();
-        for dep_id in dependency_ids {
-            if let Some(token) = tokens.get(&dep_id) {
-                needed_tokens.push(Rc::clone(token))
-            }
+    // put together tokens that belong to the export
+    let mut needed_tokens = Vec::new();
+    for dep_id in dependency_ids {
+        if let Some(token) = tokens.get(&dep_id) {
+            needed_tokens.push(Rc::clone(token))
         }
-
-        // TODO[btv] - We should determine the key and permutation to use during planning,
-        // rather than at runtime.
-        //
-        // This is basically an inlined version of the old `as_collection`.
-        let bundle = self
-            .lookup_id(mz_expr::Id::Global(sink.from))
-            .expect("Sink source collection not loaded");
-        let (ok_collection, mut err_collection) = if let Some(collection) = &bundle.collection {
-            collection.clone()
-        } else {
-            let (key, _arrangement) = bundle
-                .arranged
-                .iter()
-                .next()
-                .expect("Invariant violated: at least one collection must be present.");
-            let unthinned_arity = sink.from_desc.arity();
-            let (permutation, thinning) = permutation_for_arrangement(key, unthinned_arity);
-            let mut mfp = MapFilterProject::new(unthinned_arity);
-            mfp.permute(permutation, thinning.len() + key.len());
-            bundle.as_collection_core(mfp, Some((key.clone(), None)), self.until.clone())
-        };
-
-        // Attach logging of dataflow errors.
-        if let Some(logger) = compute_state.compute_logger.clone() {
-            err_collection = err_collection.log_dataflow_errors(logger, sink_id);
-        }
-
-        let mut ok_collection = ok_collection.leave();
-        let mut err_collection = err_collection.leave();
-
-        let non_null_assertions = sink.non_null_assertions.clone();
-        let from_desc = sink.from_desc.clone();
-        if !non_null_assertions.is_empty() {
-            let (oks, null_errs) =
-                ok_collection.map_fallible("NullAssertions({sink_id:?})", move |row| {
-                    let mut idx = 0;
-                    let mut iter = row.iter();
-                    for &i in &non_null_assertions {
-                        let skip = i - idx;
-                        let datum = iter.nth(skip).unwrap();
-                        idx += skip + 1;
-                        if datum.is_null() {
-                            return Err(DataflowError::EvalError(Box::new(
-                                EvalError::MustNotBeNull(format!(
-                                    "column {}",
-                                    from_desc.get_name(i).as_str().quoted()
-                                )),
-                            )));
-                        }
-                    }
-                    Ok(row)
-                });
-            ok_collection = oks;
-            err_collection = err_collection.concat(&null_errs);
-        }
-
-        let region_name = match sink.connection {
-            ComputeSinkConnection::Subscribe(_) => format!("SubscribeSink({:?})", sink_id),
-            ComputeSinkConnection::Persist(_) => format!("PersistSink({:?})", sink_id),
-        };
-        self.scope
-            .parent
-            .clone()
-            .region_named(&region_name, |inner| {
-                let sink_render = get_sink_render_for::<_>(&sink.connection);
-
-                let sink_token = sink_render.render_continuous_sink(
-                    compute_state,
-                    sink,
-                    sink_id,
-                    self.as_of_frontier.clone(),
-                    ok_collection.enter_region(inner),
-                    err_collection.enter_region(inner),
-                );
-
-                if let Some(sink_token) = sink_token {
-                    needed_tokens.push(sink_token);
-                }
-
-                let collection = compute_state.expect_collection_mut(sink_id);
-                collection.sink_token = Some(SinkToken::new(Box::new(needed_tokens)));
-            });
     }
+
+    // TODO[btv] - We should determine the key and permutation to use during planning,
+    // rather than at runtime.
+    //
+    // This is basically an inlined version of the old `as_collection`.
+    let bundle = self
+        .lookup_id(mz_expr::Id::Global(sink.from))
+        .expect("Sink source collection not loaded");
+    let (ok_collection, mut err_collection) = if let Some(collection) = &bundle.collection {
+        collection.clone()
+    } else {
+        let (key, _arrangement) = bundle
+            .arranged
+            .iter()
+            .next()
+            .expect("Invariant violated: at least one collection must be present.");
+        let unthinned_arity = sink.from_desc.arity();
+        let (permutation, thinning) = permutation_for_arrangement(key, unthinned_arity);
+        let mut mfp = MapFilterProject::new(unthinned_arity);
+        mfp.permute(permutation, thinning.len() + key.len());
+        bundle.as_collection_core(mfp, Some((key.clone(), None)), self.until.clone())
+    };
+
+    // Attach logging of dataflow errors.
+    if let Some(logger) = compute_state.compute_logger.clone() {
+        err_collection = err_collection.log_dataflow_errors(logger, sink_id);
+    }
+
+    let mut ok_collection = ok_collection.leave();
+    let mut err_collection = err_collection.leave();
+
+    let non_null_assertions = sink.non_null_assertions.clone();
+    let from_desc = sink.from_desc.clone();
+    if !non_null_assertions.is_empty() {
+        let (oks, null_errs) =
+            ok_collection.map_fallible("NullAssertions({sink_id:?})", move |row| {
+                let mut idx = 0;
+                let mut iter = row.iter();
+                for &i in &non_null_assertions {
+                    let skip = i - idx;
+                    let datum = iter.nth(skip).unwrap();
+                    idx += skip + 1;
+                    if datum.is_null() {
+                        return Err(DataflowError::EvalError(Box::new(
+                            EvalError::MustNotBeNull(format!(
+                                "column {}",
+                                from_desc.get_name(i).as_str().quoted()
+                            )),
+                        )));
+                    }
+                }
+                Ok(row)
+            });
+        ok_collection = oks;
+        err_collection = err_collection.concat(&null_errs);
+    }
+
+    let region_name = match sink.connection {
+        ComputeSinkConnection::Subscribe(_) => format!("SubscribeSink({:?})", sink_id),
+        ComputeSinkConnection::Persist(_) => format!("PersistSink({:?})", sink_id),
+    };
+    self.scope
+        .parent
+        .clone()
+        .region_named(&region_name, |inner| {
+            let sink_render = get_sink_render_for::<_>(&sink.connection);
+
+            let sink_token = sink_render.render_continuous_sink(
+                compute_state,
+                sink,
+                sink_id,
+                self.as_of_frontier.clone(),
+                ok_collection.enter_region(inner),
+                err_collection.enter_region(inner),
+            );
+
+            if let Some(sink_token) = sink_token {
+                needed_tokens.push(sink_token);
+            }
+
+            let collection = compute_state.expect_collection_mut(sink_id);
+            collection.sink_token = Some(SinkToken::new(Box::new(needed_tokens)));
+        });
+}
 }
 
 /// A type that can be rendered as a dataflow sink.

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -151,20 +151,20 @@ where
     G::Timestamp: Lattice + Refines<T> + Columnation,
     T: Timestamp + Lattice + Columnation,
 {
-    pub(crate) fn render_threshold(
-        &self,
-        input: CollectionBundle<G, T>,
-        threshold_plan: ThresholdPlan,
-    ) -> CollectionBundle<G, T> {
-        match threshold_plan {
-            ThresholdPlan::Basic(BasicThresholdPlan {
-                ensure_arrangement: (key, _, _),
-            }) => {
-                // We do not need to apply the permutation here,
-                // since threshold doesn't inspect the values, but only
-                // their counts.
-                build_threshold_basic(input, key)
-            }
+pub(crate) fn render_threshold(
+    &self,
+    input: CollectionBundle<G, T>,
+    threshold_plan: ThresholdPlan,
+) -> CollectionBundle<G, T> {
+    match threshold_plan {
+        ThresholdPlan::Basic(BasicThresholdPlan {
+            ensure_arrangement: (key, _, _),
+        }) => {
+            // We do not need to apply the permutation here,
+            // since threshold doesn't inspect the values, but only
+            // their counts.
+            build_threshold_basic(input, key)
         }
     }
+}
 }

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -26,9 +26,9 @@ use timely::progress::Timestamp;
 use crate::extensions::arrange::{ArrangementSize, KeyCollection, MzArrange};
 use crate::extensions::reduce::MzReduce;
 use crate::render::context::{
-    ArrangementFlavor, CollectionBundle, Context, SpecializedArrangement,
-    SpecializedArrangementImport,
+    ArrangementFlavor, CollectionBundle, SpecializedArrangement, SpecializedArrangementImport,
 };
+use crate::render::RenderTimestamp;
 
 /// Shared function to compute an arrangement of values matching `logic`.
 fn threshold_arrangement<G, T1, T2, L>(
@@ -145,17 +145,14 @@ where
     }
 }
 
-impl<G, T> Context<G, T>
-where
-    G: Scope,
-    G::Timestamp: Lattice + Refines<T> + Columnation,
-    T: Timestamp + Lattice + Columnation,
-{
-pub(crate) fn render_threshold(
-    &self,
-    input: CollectionBundle<G, T>,
+pub(crate) fn render_threshold<S>(
+    input: CollectionBundle<S>,
     threshold_plan: ThresholdPlan,
-) -> CollectionBundle<G, T> {
+) -> CollectionBundle<S>
+where
+    S: Scope,
+    S::Timestamp: RenderTimestamp,
+{
     match threshold_plan {
         ThresholdPlan::Basic(BasicThresholdPlan {
             ensure_arrangement: (key, _, _),
@@ -166,5 +163,4 @@ pub(crate) fn render_threshold(
             build_threshold_basic(input, key)
         }
     }
-}
 }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -31,6 +31,7 @@ use mz_timely_util::operator::CollectionExt;
 use timely::container::columnation::Columnation;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
+use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 
 use crate::extensions::arrange::{KeyCollection, MzArrange};
@@ -46,182 +47,187 @@ pub(crate) fn render_topk<C: Context>(
     input: CollectionBundle<C::Scope>,
     top_k_plan: TopKPlan,
 ) -> CollectionBundle<C::Scope> {
-    let (ok_input, err_input) = input.as_specific_collection(None);
-
     // We create a new region to compartmentalize the topk logic.
-    let (ok_result, err_collection) = ok_input.scope().region_named("TopK", |inner| {
-        let ok_input = ok_input.enter_region(inner);
-        let mut err_collection = err_input.enter_region(inner);
+    input.scope().region_named("TopK", |inner| {
+        render_topk_inner(ctx, input, top_k_plan, inner)
+    })
+}
 
-        // Determine if there should be errors due to limit evaluation; update `err_collection`.
-        // TODO(vmarcos): We evaluate the limit expression below for each input update. There
-        // is an opportunity to do so for every group key instead if the error handling is
-        // integrated with: 1. The intra-timestamp thinning step in monotonic top-k, e.g., by
-        // adding an error output there; 2. The validating reduction on basic top-k (#23687).
-        let limit_err = match &top_k_plan {
-            TopKPlan::MonotonicTop1(MonotonicTop1Plan { .. }) => None,
-            TopKPlan::MonotonicTopK(MonotonicTopKPlan { limit, .. }) => Some(limit),
-            TopKPlan::Basic(BasicTopKPlan { limit, .. }) => Some(limit),
-        };
-        if let Some(limit) = limit_err {
-            if let Some(expr) = limit {
-                // Produce errors from limit selectors that error or are
-                // negative, and nothing from limit selectors that do
-                // not. Note that even if expr.could_error() is false,
-                // the expression might still return a negative limit and
-                // thus needs to be checked.
-                let expr = expr.clone();
-                let mut datum_vec = mz_repr::DatumVec::new();
-                let errors = ok_input.flat_map(move |row| {
-                    let temp_storage = mz_repr::RowArena::new();
-                    let datums = datum_vec.borrow_with(&row);
-                    match expr.eval(&datums[..], &temp_storage) {
-                        Ok(l) if l != Datum::Null && l.unwrap_int64() < 0 => {
-                            Some(EvalError::NegLimit.into())
-                        }
-                        Ok(_) => None,
-                        Err(e) => Some(e.into()),
+fn render_topk_inner<C: Context>(
+    ctx: &C,
+    input: CollectionBundle<C::Scope>,
+    top_k_plan: TopKPlan,
+    inner: &Child<C::Scope, C::Timestamp>,
+) -> CollectionBundle<C::Scope> {
+    let (ok_input, err_input) = input.as_specific_collection(None);
+    let ok_input = ok_input.enter_region(inner);
+    let mut err_collection = err_input.enter_region(inner);
+
+    // Determine if there should be errors due to limit evaluation; update `err_collection`.
+    // TODO(vmarcos): We evaluate the limit expression below for each input update. There
+    // is an opportunity to do so for every group key instead if the error handling is
+    // integrated with: 1. The intra-timestamp thinning step in monotonic top-k, e.g., by
+    // adding an error output there; 2. The validating reduction on basic top-k (#23687).
+    let limit_err = match &top_k_plan {
+        TopKPlan::MonotonicTop1(MonotonicTop1Plan { .. }) => None,
+        TopKPlan::MonotonicTopK(MonotonicTopKPlan { limit, .. }) => Some(limit),
+        TopKPlan::Basic(BasicTopKPlan { limit, .. }) => Some(limit),
+    };
+    if let Some(limit) = limit_err {
+        if let Some(expr) = limit {
+            // Produce errors from limit selectors that error or are
+            // negative, and nothing from limit selectors that do
+            // not. Note that even if expr.could_error() is false,
+            // the expression might still return a negative limit and
+            // thus needs to be checked.
+            let expr = expr.clone();
+            let mut datum_vec = mz_repr::DatumVec::new();
+            let errors = ok_input.flat_map(move |row| {
+                let temp_storage = mz_repr::RowArena::new();
+                let datums = datum_vec.borrow_with(&row);
+                match expr.eval(&datums[..], &temp_storage) {
+                    Ok(l) if l != Datum::Null && l.unwrap_int64() < 0 => {
+                        Some(EvalError::NegLimit.into())
                     }
-                });
-                err_collection = err_collection.concat(&errors);
-            }
+                    Ok(_) => None,
+                    Err(e) => Some(e.into()),
+                }
+            });
+            err_collection = err_collection.concat(&errors);
         }
+    }
 
-        let ok_result = match top_k_plan {
-            TopKPlan::MonotonicTop1(MonotonicTop1Plan {
-                group_key,
-                order_key,
-                must_consolidate,
-            }) => {
-                let (oks, errs) =
-                    render_top1_monotonic(ctx, ok_input, group_key, order_key, must_consolidate);
-                err_collection = err_collection.concat(&errs);
-                oks
-            }
-            TopKPlan::MonotonicTopK(MonotonicTopKPlan {
-                order_key,
-                group_key,
-                arity,
-                mut limit,
-                must_consolidate,
-            }) => {
-                // Must permute `limit` to reference `group_key` elements as if in order.
-                if let Some(expr) = limit.as_mut() {
-                    let mut map = BTreeMap::new();
-                    for (index, column) in group_key.iter().enumerate() {
-                        map.insert(*column, index);
-                    }
-                    expr.permute_map(&map);
+    let ok_result = match top_k_plan {
+        TopKPlan::MonotonicTop1(MonotonicTop1Plan {
+            group_key,
+            order_key,
+            must_consolidate,
+        }) => {
+            let (oks, errs) =
+                render_top1_monotonic(ctx, ok_input, group_key, order_key, must_consolidate);
+            err_collection = err_collection.concat(&errs);
+            oks
+        }
+        TopKPlan::MonotonicTopK(MonotonicTopKPlan {
+            order_key,
+            group_key,
+            arity,
+            mut limit,
+            must_consolidate,
+        }) => {
+            // Must permute `limit` to reference `group_key` elements as if in order.
+            if let Some(expr) = limit.as_mut() {
+                let mut map = BTreeMap::new();
+                for (index, column) in group_key.iter().enumerate() {
+                    map.insert(*column, index);
                 }
-
-                // Map the group key along with the row and consolidate if required to do so.
-                let mut datum_vec = mz_repr::DatumVec::new();
-                let collection = ok_input
-                    .map(move |row| {
-                        let binding = SharedRow::get();
-                        let mut row_builder = binding.borrow_mut();
-                        let group_row = {
-                            let datums = datum_vec.borrow_with(&row);
-                            let iterator = group_key.iter().map(|i| datums[*i]);
-                            row_builder.packer().extend(iterator);
-                            row_builder.clone()
-                        };
-                        (group_row, row)
-                    })
-                    .consolidate_named_if::<KeySpine<_, _, _>>(
-                        must_consolidate,
-                        "Consolidated MonotonicTopK input",
-                    );
-
-                // It should be now possible to ensure that we have a monotonic collection.
-                let error_logger = ctx.error_logger();
-                let (collection, errs) = collection.ensure_monotonic(move |data, diff| {
-                    error_logger.log(
-                        "Non-monotonic input to MonotonicTopK",
-                        &format!("data={data:?}, diff={diff}"),
-                    );
-                    let m = "tried to build monotonic top-k on non-monotonic input".to_string();
-                    (DataflowError::from(EvalError::Internal(m)), 1)
-                });
-                err_collection = err_collection.concat(&errs);
-
-                // For monotonic inputs, we are able to thin the input relation in two stages:
-                // 1. First, we can do an intra-timestamp thinning which has the advantage of
-                //    being computed in a streaming fashion, even for the initial snapshot.
-                // 2. Then, we can do inter-timestamp thinning by feeding back negations for
-                //    any records that have been invalidated.
-                let collection = if let Some(limit) = limit.clone() {
-                    render_intra_ts_thinning(collection, order_key.clone(), limit)
-                } else {
-                    collection
-                };
-
-                let collection =
-                    collection.map(|(group_row, row)| ((group_row, row.hashed()), row));
-
-                // For monotonic inputs, we are able to retract inputs that can no longer be produced
-                // as outputs. Any inputs beyond `offset + limit` will never again be produced as
-                // outputs, and can be removed. The simplest form of this is when `offset == 0` and
-                // these removable records are those in the input not produced in the output.
-                // TODO: consider broadening this optimization to `offset > 0` by first filtering
-                // down to `offset = 0` and `limit = offset + limit`, followed by a finishing act
-                // of `offset` and `limit`, discarding only the records not produced in the intermediate
-                // stage.
-                use differential_dataflow::operators::iterate::Variable;
-                let delay = std::time::Duration::from_secs(10);
-                let retractions = Variable::new(
-                    &mut ok_input.scope(),
-                    <C::Timestamp as crate::render::RenderTimestamp>::system_delay(
-                        delay.try_into().expect("must fit"),
-                    ),
-                );
-                let thinned = collection.concat(&retractions.negate());
-
-                // As an additional optimization, we can skip creating the full topk hierachy
-                // here since we now have an upper bound on the number records due to the
-                // intra-ts thinning. The maximum number of records per timestamp is
-                // (num_workers * limit), which we expect to be a small number and so we render
-                // a single topk stage.
-                let (result, errs) =
-                    build_topk_stage(ctx, thinned, order_key, 1u64, 0, limit, arity, false);
-                retractions.set(&collection.concat(&result.negate()));
-                soft_assert_or_log!(
-                    errs.is_none(),
-                    "requested no validation, but received error collection"
-                );
-
-                result.map(|((_key, _hash), row)| row)
+                expr.permute_map(&map);
             }
-            TopKPlan::Basic(BasicTopKPlan {
-                group_key,
-                order_key,
-                offset,
-                mut limit,
-                arity,
-                buckets,
-            }) => {
-                // Must permute `limit` to reference `group_key` elements as if in order.
-                if let Some(expr) = limit.as_mut() {
-                    let mut map = BTreeMap::new();
-                    for (index, column) in group_key.iter().enumerate() {
-                        map.insert(*column, index);
-                    }
-                    expr.permute_map(&map);
+
+            // Map the group key along with the row and consolidate if required to do so.
+            let mut datum_vec = mz_repr::DatumVec::new();
+            let collection = ok_input
+                .map(move |row| {
+                    let binding = SharedRow::get();
+                    let mut row_builder = binding.borrow_mut();
+                    let group_row = {
+                        let datums = datum_vec.borrow_with(&row);
+                        let iterator = group_key.iter().map(|i| datums[*i]);
+                        row_builder.packer().extend(iterator);
+                        row_builder.clone()
+                    };
+                    (group_row, row)
+                })
+                .consolidate_named_if::<KeySpine<_, _, _>>(
+                    must_consolidate,
+                    "Consolidated MonotonicTopK input",
+                );
+
+            // It should be now possible to ensure that we have a monotonic collection.
+            let error_logger = ctx.error_logger();
+            let (collection, errs) = collection.ensure_monotonic(move |data, diff| {
+                error_logger.log(
+                    "Non-monotonic input to MonotonicTopK",
+                    &format!("data={data:?}, diff={diff}"),
+                );
+                let m = "tried to build monotonic top-k on non-monotonic input".to_string();
+                (DataflowError::from(EvalError::Internal(m)), 1)
+            });
+            err_collection = err_collection.concat(&errs);
+
+            // For monotonic inputs, we are able to thin the input relation in two stages:
+            // 1. First, we can do an intra-timestamp thinning which has the advantage of
+            //    being computed in a streaming fashion, even for the initial snapshot.
+            // 2. Then, we can do inter-timestamp thinning by feeding back negations for
+            //    any records that have been invalidated.
+            let collection = if let Some(limit) = limit.clone() {
+                render_intra_ts_thinning(collection, order_key.clone(), limit)
+            } else {
+                collection
+            };
+
+            let collection = collection.map(|(group_row, row)| ((group_row, row.hashed()), row));
+
+            // For monotonic inputs, we are able to retract inputs that can no longer be produced
+            // as outputs. Any inputs beyond `offset + limit` will never again be produced as
+            // outputs, and can be removed. The simplest form of this is when `offset == 0` and
+            // these removable records are those in the input not produced in the output.
+            // TODO: consider broadening this optimization to `offset > 0` by first filtering
+            // down to `offset = 0` and `limit = offset + limit`, followed by a finishing act
+            // of `offset` and `limit`, discarding only the records not produced in the intermediate
+            // stage.
+            use differential_dataflow::operators::iterate::Variable;
+            let delay = std::time::Duration::from_secs(10);
+            let retractions = Variable::new(
+                &mut ok_input.scope(),
+                <C::Timestamp as crate::render::RenderTimestamp>::system_delay(
+                    delay.try_into().expect("must fit"),
+                ),
+            );
+            let thinned = collection.concat(&retractions.negate());
+
+            // As an additional optimization, we can skip creating the full topk hierachy
+            // here since we now have an upper bound on the number records due to the
+            // intra-ts thinning. The maximum number of records per timestamp is
+            // (num_workers * limit), which we expect to be a small number and so we render
+            // a single topk stage.
+            let (result, errs) =
+                build_topk_stage(ctx, thinned, order_key, 1u64, 0, limit, arity, false);
+            retractions.set(&collection.concat(&result.negate()));
+            soft_assert_or_log!(
+                errs.is_none(),
+                "requested no validation, but received error collection"
+            );
+
+            result.map(|((_key, _hash), row)| row)
+        }
+        TopKPlan::Basic(BasicTopKPlan {
+            group_key,
+            order_key,
+            offset,
+            mut limit,
+            arity,
+            buckets,
+        }) => {
+            // Must permute `limit` to reference `group_key` elements as if in order.
+            if let Some(expr) = limit.as_mut() {
+                let mut map = BTreeMap::new();
+                for (index, column) in group_key.iter().enumerate() {
+                    map.insert(*column, index);
                 }
-
-                let (oks, errs) = build_topk(
-                    ctx, ok_input, group_key, order_key, offset, limit, arity, buckets,
-                );
-                err_collection = err_collection.concat(&errs);
-                oks
+                expr.permute_map(&map);
             }
-        };
 
-        // Extract the results from the region.
-        (ok_result.leave_region(), err_collection.leave_region())
-    });
+            let (oks, errs) = build_topk(
+                ctx, ok_input, group_key, order_key, offset, limit, arity, buckets,
+            );
+            err_collection = err_collection.concat(&errs);
+            oks
+        }
+    };
 
-    CollectionBundle::from_collections(ok_result, err_collection)
+    // Extract the results from the region.
+    CollectionBundle::from_collections(ok_result.leave_region(), err_collection.leave_region())
 }
 
 /// Constructs a TopK dataflow subgraph.

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -45,412 +45,408 @@ where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
 {
-    pub(crate) fn render_topk(
-        &mut self,
-        input: CollectionBundle<G>,
-        top_k_plan: TopKPlan,
-    ) -> CollectionBundle<G> {
-        let (ok_input, err_input) = input.as_specific_collection(None);
+pub(crate) fn render_topk(
+    &mut self,
+    input: CollectionBundle<G>,
+    top_k_plan: TopKPlan,
+) -> CollectionBundle<G> {
+    let (ok_input, err_input) = input.as_specific_collection(None);
 
-        // We create a new region to compartmentalize the topk logic.
-        let (ok_result, err_collection) = ok_input.scope().region_named("TopK", |inner| {
-            let ok_input = ok_input.enter_region(inner);
-            let mut err_collection = err_input.enter_region(inner);
+    // We create a new region to compartmentalize the topk logic.
+    let (ok_result, err_collection) = ok_input.scope().region_named("TopK", |inner| {
+        let ok_input = ok_input.enter_region(inner);
+        let mut err_collection = err_input.enter_region(inner);
 
-            // Determine if there should be errors due to limit evaluation; update `err_collection`.
-            // TODO(vmarcos): We evaluate the limit expression below for each input update. There
-            // is an opportunity to do so for every group key instead if the error handling is
-            // integrated with: 1. The intra-timestamp thinning step in monotonic top-k, e.g., by
-            // adding an error output there; 2. The validating reduction on basic top-k (#23687).
-            let limit_err = match &top_k_plan {
-                TopKPlan::MonotonicTop1(MonotonicTop1Plan { .. }) => None,
-                TopKPlan::MonotonicTopK(MonotonicTopKPlan { limit, .. }) => Some(limit),
-                TopKPlan::Basic(BasicTopKPlan { limit, .. }) => Some(limit),
-            };
-            if let Some(limit) = limit_err {
-                if let Some(expr) = limit {
-                    // Produce errors from limit selectors that error or are
-                    // negative, and nothing from limit selectors that do
-                    // not. Note that even if expr.could_error() is false,
-                    // the expression might still return a negative limit and
-                    // thus needs to be checked.
-                    let expr = expr.clone();
-                    let mut datum_vec = mz_repr::DatumVec::new();
-                    let errors = ok_input.flat_map(move |row| {
-                        let temp_storage = mz_repr::RowArena::new();
-                        let datums = datum_vec.borrow_with(&row);
-                        match expr.eval(&datums[..], &temp_storage) {
-                            Ok(l) if l != Datum::Null && l.unwrap_int64() < 0 => {
-                                Some(EvalError::NegLimit.into())
-                            }
-                            Ok(_) => None,
-                            Err(e) => Some(e.into()),
+        // Determine if there should be errors due to limit evaluation; update `err_collection`.
+        // TODO(vmarcos): We evaluate the limit expression below for each input update. There
+        // is an opportunity to do so for every group key instead if the error handling is
+        // integrated with: 1. The intra-timestamp thinning step in monotonic top-k, e.g., by
+        // adding an error output there; 2. The validating reduction on basic top-k (#23687).
+        let limit_err = match &top_k_plan {
+            TopKPlan::MonotonicTop1(MonotonicTop1Plan { .. }) => None,
+            TopKPlan::MonotonicTopK(MonotonicTopKPlan { limit, .. }) => Some(limit),
+            TopKPlan::Basic(BasicTopKPlan { limit, .. }) => Some(limit),
+        };
+        if let Some(limit) = limit_err {
+            if let Some(expr) = limit {
+                // Produce errors from limit selectors that error or are
+                // negative, and nothing from limit selectors that do
+                // not. Note that even if expr.could_error() is false,
+                // the expression might still return a negative limit and
+                // thus needs to be checked.
+                let expr = expr.clone();
+                let mut datum_vec = mz_repr::DatumVec::new();
+                let errors = ok_input.flat_map(move |row| {
+                    let temp_storage = mz_repr::RowArena::new();
+                    let datums = datum_vec.borrow_with(&row);
+                    match expr.eval(&datums[..], &temp_storage) {
+                        Ok(l) if l != Datum::Null && l.unwrap_int64() < 0 => {
+                            Some(EvalError::NegLimit.into())
                         }
-                    });
-                    err_collection = err_collection.concat(&errors);
-                }
+                        Ok(_) => None,
+                        Err(e) => Some(e.into()),
+                    }
+                });
+                err_collection = err_collection.concat(&errors);
             }
+        }
 
-            let ok_result = match top_k_plan {
-                TopKPlan::MonotonicTop1(MonotonicTop1Plan {
-                    group_key,
-                    order_key,
-                    must_consolidate,
-                }) => {
-                    let (oks, errs) = self.render_top1_monotonic(
-                        ok_input,
-                        group_key,
-                        order_key,
+        let ok_result = match top_k_plan {
+            TopKPlan::MonotonicTop1(MonotonicTop1Plan {
+                group_key,
+                order_key,
+                must_consolidate,
+            }) => {
+                let (oks, errs) =
+                    self.render_top1_monotonic(ok_input, group_key, order_key, must_consolidate);
+                err_collection = err_collection.concat(&errs);
+                oks
+            }
+            TopKPlan::MonotonicTopK(MonotonicTopKPlan {
+                order_key,
+                group_key,
+                arity,
+                mut limit,
+                must_consolidate,
+            }) => {
+                // Must permute `limit` to reference `group_key` elements as if in order.
+                if let Some(expr) = limit.as_mut() {
+                    let mut map = BTreeMap::new();
+                    for (index, column) in group_key.iter().enumerate() {
+                        map.insert(*column, index);
+                    }
+                    expr.permute_map(&map);
+                }
+
+                // Map the group key along with the row and consolidate if required to do so.
+                let mut datum_vec = mz_repr::DatumVec::new();
+                let collection = ok_input
+                    .map(move |row| {
+                        let binding = SharedRow::get();
+                        let mut row_builder = binding.borrow_mut();
+                        let group_row = {
+                            let datums = datum_vec.borrow_with(&row);
+                            let iterator = group_key.iter().map(|i| datums[*i]);
+                            row_builder.packer().extend(iterator);
+                            row_builder.clone()
+                        };
+                        (group_row, row)
+                    })
+                    .consolidate_named_if::<KeySpine<_, _, _>>(
                         must_consolidate,
+                        "Consolidated MonotonicTopK input",
                     );
-                    err_collection = err_collection.concat(&errs);
-                    oks
-                }
-                TopKPlan::MonotonicTopK(MonotonicTopKPlan {
-                    order_key,
-                    group_key,
-                    arity,
-                    mut limit,
-                    must_consolidate,
-                }) => {
-                    // Must permute `limit` to reference `group_key` elements as if in order.
-                    if let Some(expr) = limit.as_mut() {
-                        let mut map = BTreeMap::new();
-                        for (index, column) in group_key.iter().enumerate() {
-                            map.insert(*column, index);
-                        }
-                        expr.permute_map(&map);
+
+                // It should be now possible to ensure that we have a monotonic collection.
+                let error_logger = self.error_logger();
+                let (collection, errs) = collection.ensure_monotonic(move |data, diff| {
+                    error_logger.log(
+                        "Non-monotonic input to MonotonicTopK",
+                        &format!("data={data:?}, diff={diff}"),
+                    );
+                    let m = "tried to build monotonic top-k on non-monotonic input".to_string();
+                    (DataflowError::from(EvalError::Internal(m)), 1)
+                });
+                err_collection = err_collection.concat(&errs);
+
+                // For monotonic inputs, we are able to thin the input relation in two stages:
+                // 1. First, we can do an intra-timestamp thinning which has the advantage of
+                //    being computed in a streaming fashion, even for the initial snapshot.
+                // 2. Then, we can do inter-timestamp thinning by feeding back negations for
+                //    any records that have been invalidated.
+                let collection = if let Some(limit) = limit.clone() {
+                    render_intra_ts_thinning(collection, order_key.clone(), limit)
+                } else {
+                    collection
+                };
+
+                let collection =
+                    collection.map(|(group_row, row)| ((group_row, row.hashed()), row));
+
+                // For monotonic inputs, we are able to retract inputs that can no longer be produced
+                // as outputs. Any inputs beyond `offset + limit` will never again be produced as
+                // outputs, and can be removed. The simplest form of this is when `offset == 0` and
+                // these removable records are those in the input not produced in the output.
+                // TODO: consider broadening this optimization to `offset > 0` by first filtering
+                // down to `offset = 0` and `limit = offset + limit`, followed by a finishing act
+                // of `offset` and `limit`, discarding only the records not produced in the intermediate
+                // stage.
+                use differential_dataflow::operators::iterate::Variable;
+                let delay = std::time::Duration::from_secs(10);
+                let retractions = Variable::new(
+                    &mut ok_input.scope(),
+                    <G::Timestamp as crate::render::RenderTimestamp>::system_delay(
+                        delay.try_into().expect("must fit"),
+                    ),
+                );
+                let thinned = collection.concat(&retractions.negate());
+
+                // As an additional optimization, we can skip creating the full topk hierachy
+                // here since we now have an upper bound on the number records due to the
+                // intra-ts thinning. The maximum number of records per timestamp is
+                // (num_workers * limit), which we expect to be a small number and so we render
+                // a single topk stage.
+                let (result, errs) =
+                    self.build_topk_stage(thinned, order_key, 1u64, 0, limit, arity, false);
+                retractions.set(&collection.concat(&result.negate()));
+                soft_assert_or_log!(
+                    errs.is_none(),
+                    "requested no validation, but received error collection"
+                );
+
+                result.map(|((_key, _hash), row)| row)
+            }
+            TopKPlan::Basic(BasicTopKPlan {
+                group_key,
+                order_key,
+                offset,
+                mut limit,
+                arity,
+                buckets,
+            }) => {
+                // Must permute `limit` to reference `group_key` elements as if in order.
+                if let Some(expr) = limit.as_mut() {
+                    let mut map = BTreeMap::new();
+                    for (index, column) in group_key.iter().enumerate() {
+                        map.insert(*column, index);
                     }
-
-                    // Map the group key along with the row and consolidate if required to do so.
-                    let mut datum_vec = mz_repr::DatumVec::new();
-                    let collection = ok_input
-                        .map(move |row| {
-                            let binding = SharedRow::get();
-                            let mut row_builder = binding.borrow_mut();
-                            let group_row = {
-                                let datums = datum_vec.borrow_with(&row);
-                                let iterator = group_key.iter().map(|i| datums[*i]);
-                                row_builder.packer().extend(iterator);
-                                row_builder.clone()
-                            };
-                            (group_row, row)
-                        })
-                        .consolidate_named_if::<KeySpine<_, _, _>>(
-                            must_consolidate,
-                            "Consolidated MonotonicTopK input",
-                        );
-
-                    // It should be now possible to ensure that we have a monotonic collection.
-                    let error_logger = self.error_logger();
-                    let (collection, errs) = collection.ensure_monotonic(move |data, diff| {
-                        error_logger.log(
-                            "Non-monotonic input to MonotonicTopK",
-                            &format!("data={data:?}, diff={diff}"),
-                        );
-                        let m = "tried to build monotonic top-k on non-monotonic input".to_string();
-                        (DataflowError::from(EvalError::Internal(m)), 1)
-                    });
-                    err_collection = err_collection.concat(&errs);
-
-                    // For monotonic inputs, we are able to thin the input relation in two stages:
-                    // 1. First, we can do an intra-timestamp thinning which has the advantage of
-                    //    being computed in a streaming fashion, even for the initial snapshot.
-                    // 2. Then, we can do inter-timestamp thinning by feeding back negations for
-                    //    any records that have been invalidated.
-                    let collection = if let Some(limit) = limit.clone() {
-                        render_intra_ts_thinning(collection, order_key.clone(), limit)
-                    } else {
-                        collection
-                    };
-
-                    let collection =
-                        collection.map(|(group_row, row)| ((group_row, row.hashed()), row));
-
-                    // For monotonic inputs, we are able to retract inputs that can no longer be produced
-                    // as outputs. Any inputs beyond `offset + limit` will never again be produced as
-                    // outputs, and can be removed. The simplest form of this is when `offset == 0` and
-                    // these removable records are those in the input not produced in the output.
-                    // TODO: consider broadening this optimization to `offset > 0` by first filtering
-                    // down to `offset = 0` and `limit = offset + limit`, followed by a finishing act
-                    // of `offset` and `limit`, discarding only the records not produced in the intermediate
-                    // stage.
-                    use differential_dataflow::operators::iterate::Variable;
-                    let delay = std::time::Duration::from_secs(10);
-                    let retractions = Variable::new(
-                        &mut ok_input.scope(),
-                        <G::Timestamp as crate::render::RenderTimestamp>::system_delay(
-                            delay.try_into().expect("must fit"),
-                        ),
-                    );
-                    let thinned = collection.concat(&retractions.negate());
-
-                    // As an additional optimization, we can skip creating the full topk hierachy
-                    // here since we now have an upper bound on the number records due to the
-                    // intra-ts thinning. The maximum number of records per timestamp is
-                    // (num_workers * limit), which we expect to be a small number and so we render
-                    // a single topk stage.
-                    let (result, errs) =
-                        self.build_topk_stage(thinned, order_key, 1u64, 0, limit, arity, false);
-                    retractions.set(&collection.concat(&result.negate()));
-                    soft_assert_or_log!(
-                        errs.is_none(),
-                        "requested no validation, but received error collection"
-                    );
-
-                    result.map(|((_key, _hash), row)| row)
+                    expr.permute_map(&map);
                 }
-                TopKPlan::Basic(BasicTopKPlan {
-                    group_key,
-                    order_key,
-                    offset,
-                    mut limit,
-                    arity,
-                    buckets,
-                }) => {
-                    // Must permute `limit` to reference `group_key` elements as if in order.
-                    if let Some(expr) = limit.as_mut() {
-                        let mut map = BTreeMap::new();
-                        for (index, column) in group_key.iter().enumerate() {
-                            map.insert(*column, index);
-                        }
-                        expr.permute_map(&map);
-                    }
 
-                    let (oks, errs) = self.build_topk(
-                        ok_input, group_key, order_key, offset, limit, arity, buckets,
-                    );
-                    err_collection = err_collection.concat(&errs);
-                    oks
-                }
+                let (oks, errs) = self.build_topk(
+                    ok_input, group_key, order_key, offset, limit, arity, buckets,
+                );
+                err_collection = err_collection.concat(&errs);
+                oks
+            }
+        };
+
+        // Extract the results from the region.
+        (ok_result.leave_region(), err_collection.leave_region())
+    });
+
+    CollectionBundle::from_collections(ok_result, err_collection)
+}
+
+/// Constructs a TopK dataflow subgraph.
+fn build_topk<S>(
+    &self,
+    collection: Collection<S, Row, Diff>,
+    group_key: Vec<usize>,
+    order_key: Vec<mz_expr::ColumnOrder>,
+    offset: usize,
+    limit: Option<mz_expr::MirScalarExpr>,
+    arity: usize,
+    buckets: Vec<u64>,
+) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    let mut datum_vec = mz_repr::DatumVec::new();
+    let mut collection = collection.map({
+        move |row| {
+            let binding = SharedRow::get();
+            let mut row_builder = binding.borrow_mut();
+            let row_hash = row.hashed();
+            let group_row = {
+                let datums = datum_vec.borrow_with(&row);
+                let iterator = group_key.iter().map(|i| datums[*i]);
+                row_builder.packer().extend(iterator);
+                row_builder.clone()
             };
+            ((group_row, row_hash), row)
+        }
+    });
 
-            // Extract the results from the region.
-            (ok_result.leave_region(), err_collection.leave_region())
-        });
+    let mut validating = true;
+    let mut err_collection: Option<Collection<S, _, _>> = None;
 
-        CollectionBundle::from_collections(ok_result, err_collection)
+    if let Some(mut limit) = limit.clone() {
+        // We may need a new `limit` that reflects the addition of `offset`.
+        // Ideally we compile it down to a literal if at all possible.
+        if offset > 0 {
+            let new_limit = (|| {
+                let limit = limit.as_literal_int64()?;
+                let offset = i64::try_from(offset).ok()?;
+                limit.checked_add(offset)
+            })();
+
+            if let Some(new_limit) = new_limit {
+                limit = MirScalarExpr::literal_ok(Datum::Int64(new_limit), ScalarType::Int64);
+            } else {
+                limit = limit.call_binary(
+                    MirScalarExpr::literal_ok(
+                        Datum::UInt64(u64::cast_from(offset)),
+                        ScalarType::UInt64,
+                    )
+                    .call_unary(UnaryFunc::CastUint64ToInt64(CastUint64ToInt64)),
+                    BinaryFunc::AddInt64,
+                );
+            }
+        }
+
+        // These bucket values define the shifts that happen to the 64 bit hash of the
+        // record, and should have the properties that 1. there are not too many of them,
+        // and 2. each has a modest difference to the next.
+        for bucket in buckets.into_iter() {
+            // here we do not apply `offset`, but instead restrict ourself with a limit
+            // that includes the offset. We cannot apply `offset` until we perform the
+            // final, complete reduction.
+            let (oks, errs) = self.build_topk_stage(
+                collection,
+                order_key.clone(),
+                bucket,
+                0,
+                Some(limit.clone()),
+                arity,
+                validating,
+            );
+            collection = oks;
+            if validating {
+                err_collection = errs;
+                validating = false;
+            }
+        }
     }
 
-    /// Constructs a TopK dataflow subgraph.
-    fn build_topk<S>(
-        &self,
-        collection: Collection<S, Row, Diff>,
-        group_key: Vec<usize>,
-        order_key: Vec<mz_expr::ColumnOrder>,
-        offset: usize,
-        limit: Option<mz_expr::MirScalarExpr>,
-        arity: usize,
-        buckets: Vec<u64>,
-    ) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        let mut datum_vec = mz_repr::DatumVec::new();
-        let mut collection = collection.map({
+    // We do a final step, both to make sure that we complete the reduction, and to correctly
+    // apply `offset` to the final group, as we have not yet been applying it to the partially
+    // formed groups.
+    let (oks, errs) = self.build_topk_stage(
+        collection, order_key, 1u64, offset, limit, arity, validating,
+    );
+    collection = oks;
+    if validating {
+        err_collection = errs;
+    }
+    (
+        collection.map(|((_key, _hash), row)| row),
+        err_collection.expect("at least one stage validated its inputs"),
+    )
+}
+
+// To provide a robust incremental orderby-limit experience, we want to avoid grouping *all*
+// records (or even large groups) and then applying the ordering and limit. Instead, a more
+// robust approach forms groups of bounded size and applies the offset and limit to each,
+// and then increases the sizes of the groups.
+
+// Builds a "stage", which uses a finer grouping than is required to reduce the volume of
+// updates, and to reduce the amount of work on the critical path for updates. The cost is
+// a larger number of arrangements when this optimization does nothing beneficial.
+fn build_topk_stage<S>(
+    &self,
+    collection: Collection<S, ((Row, u64), Row), Diff>,
+    order_key: Vec<mz_expr::ColumnOrder>,
+    modulus: u64,
+    offset: usize,
+    limit: Option<mz_expr::MirScalarExpr>,
+    arity: usize,
+    validating: bool,
+) -> (
+    Collection<S, ((Row, u64), Row), Diff>,
+    Option<Collection<S, DataflowError, Diff>>,
+)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
+    let (oks, errs) = if validating {
+        let stage = build_topk_negated_stage::<S, Result<Row, Row>>(
+            &input, order_key, offset, limit, arity,
+        );
+
+        let error_logger = self.error_logger();
+        let (oks, errs) =
+            stage.map_fallible("Demuxing Errors", move |((k, h), result)| match result {
+                Err(v) => {
+                    let message = "Negative multiplicities in TopK";
+                    error_logger.log(message, &format!("k={k:?}, h={h}, v={v:?}"));
+                    Err(EvalError::Internal(message.to_string()).into())
+                }
+                Ok(t) => Ok(((k, h), t)),
+            });
+        (oks, Some(errs))
+    } else {
+        (
+            build_topk_negated_stage::<S, Row>(&input, order_key, offset, limit, arity),
+            None,
+        )
+    };
+    (
+        oks.negate()
+            .concat(&input)
+            .consolidate_named::<KeySpine<_, _, _>>("Consolidated TopK"),
+        errs,
+    )
+}
+
+fn render_top1_monotonic<S>(
+    &self,
+    collection: Collection<S, Row, Diff>,
+    group_key: Vec<usize>,
+    order_key: Vec<mz_expr::ColumnOrder>,
+    must_consolidate: bool,
+) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
+where
+    S: Scope<Timestamp = G::Timestamp>,
+{
+    // We can place our rows directly into the diff field, and only keep the relevant one
+    // corresponding to evaluating our aggregate, instead of having to do a hierarchical
+    // reduction. We start by mapping the group key along with the row and consolidating
+    // if required to do so.
+    let collection = collection
+        .map({
+            let mut datum_vec = mz_repr::DatumVec::new();
             move |row| {
                 let binding = SharedRow::get();
                 let mut row_builder = binding.borrow_mut();
-                let row_hash = row.hashed();
-                let group_row = {
+                let group_key = {
                     let datums = datum_vec.borrow_with(&row);
                     let iterator = group_key.iter().map(|i| datums[*i]);
                     row_builder.packer().extend(iterator);
                     row_builder.clone()
                 };
-                ((group_row, row_hash), row)
+                (group_key, row)
             }
-        });
-
-        let mut validating = true;
-        let mut err_collection: Option<Collection<S, _, _>> = None;
-
-        if let Some(mut limit) = limit.clone() {
-            // We may need a new `limit` that reflects the addition of `offset`.
-            // Ideally we compile it down to a literal if at all possible.
-            if offset > 0 {
-                let new_limit = (|| {
-                    let limit = limit.as_literal_int64()?;
-                    let offset = i64::try_from(offset).ok()?;
-                    limit.checked_add(offset)
-                })();
-
-                if let Some(new_limit) = new_limit {
-                    limit = MirScalarExpr::literal_ok(Datum::Int64(new_limit), ScalarType::Int64);
-                } else {
-                    limit = limit.call_binary(
-                        MirScalarExpr::literal_ok(
-                            Datum::UInt64(u64::cast_from(offset)),
-                            ScalarType::UInt64,
-                        )
-                        .call_unary(UnaryFunc::CastUint64ToInt64(CastUint64ToInt64)),
-                        BinaryFunc::AddInt64,
-                    );
-                }
-            }
-
-            // These bucket values define the shifts that happen to the 64 bit hash of the
-            // record, and should have the properties that 1. there are not too many of them,
-            // and 2. each has a modest difference to the next.
-            for bucket in buckets.into_iter() {
-                // here we do not apply `offset`, but instead restrict ourself with a limit
-                // that includes the offset. We cannot apply `offset` until we perform the
-                // final, complete reduction.
-                let (oks, errs) = self.build_topk_stage(
-                    collection,
-                    order_key.clone(),
-                    bucket,
-                    0,
-                    Some(limit.clone()),
-                    arity,
-                    validating,
-                );
-                collection = oks;
-                if validating {
-                    err_collection = errs;
-                    validating = false;
-                }
-            }
-        }
-
-        // We do a final step, both to make sure that we complete the reduction, and to correctly
-        // apply `offset` to the final group, as we have not yet been applying it to the partially
-        // formed groups.
-        let (oks, errs) = self.build_topk_stage(
-            collection, order_key, 1u64, offset, limit, arity, validating,
+        })
+        .consolidate_named_if::<KeySpine<_, _, _>>(
+            must_consolidate,
+            "Consolidated MonotonicTop1 input",
         );
-        collection = oks;
-        if validating {
-            err_collection = errs;
-        }
-        (
-            collection.map(|((_key, _hash), row)| row),
-            err_collection.expect("at least one stage validated its inputs"),
-        )
-    }
 
-    // To provide a robust incremental orderby-limit experience, we want to avoid grouping *all*
-    // records (or even large groups) and then applying the ordering and limit. Instead, a more
-    // robust approach forms groups of bounded size and applies the offset and limit to each,
-    // and then increases the sizes of the groups.
-
-    // Builds a "stage", which uses a finer grouping than is required to reduce the volume of
-    // updates, and to reduce the amount of work on the critical path for updates. The cost is
-    // a larger number of arrangements when this optimization does nothing beneficial.
-    fn build_topk_stage<S>(
-        &self,
-        collection: Collection<S, ((Row, u64), Row), Diff>,
-        order_key: Vec<mz_expr::ColumnOrder>,
-        modulus: u64,
-        offset: usize,
-        limit: Option<mz_expr::MirScalarExpr>,
-        arity: usize,
-        validating: bool,
-    ) -> (
-        Collection<S, ((Row, u64), Row), Diff>,
-        Option<Collection<S, DataflowError, Diff>>,
-    )
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
-        let (oks, errs) = if validating {
-            let stage = build_topk_negated_stage::<S, Result<Row, Row>>(
-                &input, order_key, offset, limit, arity,
-            );
-
-            let error_logger = self.error_logger();
-            let (oks, errs) =
-                stage.map_fallible("Demuxing Errors", move |((k, h), result)| match result {
-                    Err(v) => {
-                        let message = "Negative multiplicities in TopK";
-                        error_logger.log(message, &format!("k={k:?}, h={h}, v={v:?}"));
-                        Err(EvalError::Internal(message.to_string()).into())
-                    }
-                    Ok(t) => Ok(((k, h), t)),
-                });
-            (oks, Some(errs))
-        } else {
+    // It should be now possible to ensure that we have a monotonic collection and process it.
+    let error_logger = self.error_logger();
+    let (partial, errs) = collection.ensure_monotonic(move |data, diff| {
+        error_logger.log(
+            "Non-monotonic input to MonotonicTop1",
+            &format!("data={data:?}, diff={diff}"),
+        );
+        let m = "tried to build monotonic top-1 on non-monotonic input".to_string();
+        (EvalError::Internal(m).into(), 1)
+    });
+    let partial: KeyCollection<_, _, _> = partial
+        .explode_one(move |(group_key, row)| {
             (
-                build_topk_negated_stage::<S, Row>(&input, order_key, offset, limit, arity),
-                None,
+                group_key,
+                monoids::Top1Monoid {
+                    row,
+                    order_key: order_key.clone(),
+                },
             )
-        };
-        (
-            oks.negate()
-                .concat(&input)
-                .consolidate_named::<KeySpine<_, _, _>>("Consolidated TopK"),
-            errs,
-        )
-    }
-
-    fn render_top1_monotonic<S>(
-        &self,
-        collection: Collection<S, Row, Diff>,
-        group_key: Vec<usize>,
-        order_key: Vec<mz_expr::ColumnOrder>,
-        must_consolidate: bool,
-    ) -> (Collection<S, Row, Diff>, Collection<S, DataflowError, Diff>)
-    where
-        S: Scope<Timestamp = G::Timestamp>,
-    {
-        // We can place our rows directly into the diff field, and only keep the relevant one
-        // corresponding to evaluating our aggregate, instead of having to do a hierarchical
-        // reduction. We start by mapping the group key along with the row and consolidating
-        // if required to do so.
-        let collection = collection
-            .map({
-                let mut datum_vec = mz_repr::DatumVec::new();
-                move |row| {
-                    let binding = SharedRow::get();
-                    let mut row_builder = binding.borrow_mut();
-                    let group_key = {
-                        let datums = datum_vec.borrow_with(&row);
-                        let iterator = group_key.iter().map(|i| datums[*i]);
-                        row_builder.packer().extend(iterator);
-                        row_builder.clone()
-                    };
-                    (group_key, row)
-                }
-            })
-            .consolidate_named_if::<KeySpine<_, _, _>>(
-                must_consolidate,
-                "Consolidated MonotonicTop1 input",
-            );
-
-        // It should be now possible to ensure that we have a monotonic collection and process it.
-        let error_logger = self.error_logger();
-        let (partial, errs) = collection.ensure_monotonic(move |data, diff| {
-            error_logger.log(
-                "Non-monotonic input to MonotonicTop1",
-                &format!("data={data:?}, diff={diff}"),
-            );
-            let m = "tried to build monotonic top-1 on non-monotonic input".to_string();
-            (EvalError::Internal(m).into(), 1)
+        })
+        .into();
+    let result = partial
+        .mz_arrange::<RowSpine<_, _>>("Arranged MonotonicTop1 partial [val: empty]")
+        .mz_reduce_abelian::<_, RowRowSpine<_, _>>("MonotonicTop1", {
+            move |_key, input, output| {
+                let accum: &monoids::Top1Monoid = &input[0].1;
+                output.push((accum.row.clone(), 1));
+            }
         });
-        let partial: KeyCollection<_, _, _> = partial
-            .explode_one(move |(group_key, row)| {
-                (
-                    group_key,
-                    monoids::Top1Monoid {
-                        row,
-                        order_key: order_key.clone(),
-                    },
-                )
-            })
-            .into();
-        let result = partial
-            .mz_arrange::<RowSpine<_, _>>("Arranged MonotonicTop1 partial [val: empty]")
-            .mz_reduce_abelian::<_, RowRowSpine<_, _>>("MonotonicTop1", {
-                move |_key, input, output| {
-                    let accum: &monoids::Top1Monoid = &input[0].1;
-                    output.push((accum.row.clone(), 1));
-                }
-            });
-        // TODO(#7331): Here we discard the arranged output.
-        use differential_dataflow::trace::cursor::MyTrait;
-        (result.as_collection(|_k, v| v.into_owned()), errs)
-    }
+    // TODO(#7331): Here we discard the arranged output.
+    use differential_dataflow::trace::cursor::MyTrait;
+    (result.as_collection(|_k, v| v.into_owned()), errs)
+}
 }
 
 fn build_topk_negated_stage<G, R>(


### PR DESCRIPTION
This PR demonstrates the use of nested contexts in rendering.

It replaces the `Context` struct with a trait that works analogous to Timely's `Scope` trait. It is implemented by two structs, `RootContext` and `ChildContext`. These two types allow constructing a context hierarchy (`RootContext` -> `ChildContext` -> `ChildContext` -> ...). Each level in the hierarchy corresponds to a dataflow region and contains a separate set of `Id` bindings. Bindings are always stored in the current context, but can be looked up from parent contexts too. Other context information, like the `dataflow_id` or the `shutdown_token`, is shared between all members of the hierarchy.

Child contexts are created every time we render a new dataflow region. The `Context` trait provides a convenient `region` method to create a new dataflow region and a corresponding child context.

There are two benefits to this organization:

* Rendering functions now only have to worry about a single scope, namely the one of the `Context` passed to them. Previously, many rendering functions would take a separate scope type `S` to specify the current scope because the context's scope was always the root scope.
* Rendering functions now have access to a `bindings` map that contains collections in the current rendering scope, rather than in the root scope. This allows them to store and retrieve collections within the correct scope directly, rather than having to `enter`/`leave` them from/into the root scope.

The second benefit is the main motivation for this change: It allows rendering the recursive part of `LetRec` nodes inside a separate region while the non-recursive part is rendered outside. Without nested context bound collections within the WMR region would have to be `leave_region()`'d to be inserted into the context's `bindings` and `enter_region()`'d every time they are used. Apart from producing hard to read code, this also produces a bunch of superfluous enter/leave edges on the dataflow graph, introducing noise there.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

The total diff is huge, but that's mostly because converting `Context` from a struct to a trait required making all of `Context`'s method free-standing functions, which introduced a huge amount of indentation changes. I included two preparatory commits that don't do much apart from moving code to ensure the subsequent commits have small diffs.

I suggest reviewing the commits separately. The code move commits should be pretty skimable with whitespace disabled.

This PR could be multiple smaller PRs instead, and I will split it if we decide to go forward with this idea. But I think having it all together helps with understanding how this restructuring is useful. The last commit is actually not part of the refactor but adds a new feature, namely LIR node regions, as a usage example.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
